### PR TITLE
Docker Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-config-ui-x",
-  "version": "3.0.0",
+  "version": "3.0.1-1",
   "description": "Configuration UI plugin for Homebridge",
   "license": "MIT",
   "keywords": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { ServerRouter } from './routes/server';
 import { ConfigRouter } from './routes/config';
 import { PackageRouter } from './routes/packages';
 import { AccessoriesRouter } from './routes/accessories';
+import { DockerRouter } from './routes/docker';
 
 export class ExpressServer {
   public app: Express;
@@ -53,6 +54,11 @@ export class ExpressServer {
     this.app.use('/api/packages', new PackageRouter().router);
     this.app.use('/api/config', new ConfigRouter().router);
     this.app.use('/api/accessories', new AccessoriesRouter().router);
+
+    // docker specific routes
+    if (hb.runningInDocker) {
+      this.app.use('/api/docker', new DockerRouter().router);
+    }
 
     // serve index.html for anything not on the /api routes
     this.app.get(/^((?!api\/).)*$/, this.auth.staticAuth, this.serveSpa);

--- a/src/hb.ts
+++ b/src/hb.ts
@@ -12,6 +12,7 @@ class HomebridgeUI {
   public homebridgeNpmPkg: string;
   public homebridgeFork: string;
   public homebridgeConfig: HomebridgeConfigType;
+  public runningInDocker: boolean;
   public configPath: string;
   public authPath: string;
   public storagePath: string;
@@ -65,6 +66,7 @@ class HomebridgeUI {
     this.homebridgeFork = config.fork;
     this.homebridgeNpmPkg = config.homebridgeNpmPkg || 'homebridge';
     this.homebridgeInsecure = config.homebridgeInsecure;
+    this.runningInDocker = Boolean(process.env.HOMEBRIDGE_CONFIG_UI === '1');
     this.disableNsp = config.disableNsp;
 
     if (config.auth === 'none' || config.auth === false) {

--- a/src/routes/docker.ts
+++ b/src/routes/docker.ts
@@ -1,0 +1,44 @@
+/* This class and it's methods are only used when running in the oznu/homebridge docker container */
+
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as child_process from 'child_process';
+import { Router, Request, Response, NextFunction } from 'express';
+
+import { hb } from '../hb';
+import { users } from '../users';
+
+export class DockerRouter {
+  public router: Router;
+
+  constructor() {
+    this.router = Router();
+
+    this.router.get('/startup-script', users.ensureAdmin, this.getStartupScript);
+    this.router.post('/startup-script', users.ensureAdmin, this.saveStartupScript);
+    this.router.put('/restart-container', users.ensureAdmin, this.restartContainer);
+  }
+
+  getStartupScript(req: Request, res: Response, next: NextFunction) {
+    res.header({'content-type': 'text/plain'});
+    return res.sendFile(path.resolve(hb.storagePath, 'startup.sh'));
+  }
+
+  saveStartupScript(req: Request, res: Response, next: NextFunction) {
+    return fs.writeFile(path.resolve(hb.storagePath, 'startup.sh'), req.body.script)
+      .then(() => {
+        hb.log('Updated startup.sh script');
+        return res.status(202).json({ok: true});
+      })
+      .catch(next);
+  }
+
+  restartContainer(req: Request, res: Response, next: NextFunction) {
+    hb.log('Request to restart docker container received');
+    res.status(202).json({ ok: true });
+
+    setTimeout(() => {
+      child_process.exec('killall s6-svscan');
+    }, 100);
+  }
+}

--- a/src/routes/settings.ts
+++ b/src/routes/settings.ts
@@ -20,7 +20,8 @@ export class SettingsRouter {
         packageVersion: hb.ui.version,
         nodeVersion: process.version,
         enableAccessories: hb.homebridgeInsecure || false,
-        homebridgeInstanceName: hb.homebridgeConfig.bridge.name || 'Homebridge'
+        homebridgeInstanceName: hb.homebridgeConfig.bridge.name || 'Homebridge',
+        runningInDocker: hb.runningInDocker
       }
     });
   }

--- a/src/users.ts
+++ b/src/users.ts
@@ -8,7 +8,7 @@ const jwt = Bluebird.promisifyAll(jsonwebtoken);
 
 import { hb } from './hb';
 
-interface User {
+export interface User {
   id: number;
   name: string;
   username: string;

--- a/src/wss/index.ts
+++ b/src/wss/index.ts
@@ -7,6 +7,7 @@ import { users } from '../users';
 import { LogsWssHandler } from './logs';
 import { StatusWssHandler } from './status';
 import { AccessoriesWssHandler} from './accessories';
+import { TerminalWssHandler } from './terminal';
 
 export class WSS {
   public server: WebSocket.Server;
@@ -21,7 +22,8 @@ export class WSS {
     this.subscriptions = {
       logs: LogsWssHandler,
       status: StatusWssHandler,
-      accessories: AccessoriesWssHandler
+      accessories: AccessoriesWssHandler,
+      terminal: TerminalWssHandler,
     };
 
     this.server.on('connection', (ws, req) => {
@@ -44,6 +46,10 @@ export class WSS {
         if (msg.accessories) {
           ws.emit('accessories', msg);
         }
+
+        if (msg.terminal) {
+          ws.emit('terminal', msg);
+        }
       });
 
       // absorb websocket errors
@@ -59,6 +65,7 @@ export class WSS {
       return users.verifyJwt(params.token)
         .then((user) => {
           if (user) {
+            info.req.user = user;
             return callback(true);
           } else {
             // invalid token - reject the websocket connection

--- a/src/wss/terminal.ts
+++ b/src/wss/terminal.ts
@@ -1,0 +1,103 @@
+import * as fs from 'fs';
+import * as WebSocket from 'ws';
+import * as pty from 'node-pty';
+import * as color from 'bash-color';
+
+import { User } from '../users';
+import { hb } from '../hb';
+
+export class TerminalWssHandler {
+  private ws: WebSocket;
+  private term: any;
+  private user: User;
+
+  constructor(ws: WebSocket, req) {
+    this.ws = ws;
+    this.user = req.user;
+
+    if (!this.user.admin) {
+      hb.warn(`[${this.user.username}]`, `Non-admin user attempted to access terminal.`);
+      return;
+    }
+
+    if (!hb.runningInDocker) {
+      this.send(color.red(`Request to spawn terminal rejected, see log for details.`));
+      hb.error(`[${this.user.username}]`, `Request to spawn terminal rejected. ` +
+        `Terminal mode is only available when running Homebridge in Docker.`);
+      return;
+    }
+
+    ws.on('terminal', (msg) => {
+      if (msg.terminal.data) {
+        this.term.write(msg.terminal.data);
+      } else if (msg.terminal.size) {
+        this.resizeTerminal(msg.terminal.size);
+      } else if (msg.terminal.start) {
+        this.startTerminal();
+      }
+    });
+
+    // when the client disconnects stop the terminal
+    const onClose = () => {
+      onUnsubscribe('terminal');
+    };
+    ws.on('close', onClose);
+
+    // when the client leaves the terminal page, stop the terminal
+    const onUnsubscribe = (sub?) => {
+      if (sub === 'terminal') {
+        ws.removeAllListeners('terminal');
+        this.killTerm();
+        ws.removeEventListener('unsubscribe', onUnsubscribe);
+        ws.removeEventListener('close', onClose);
+      }
+    };
+    ws.on('unsubscribe', onUnsubscribe);
+  }
+
+  send(data) {
+    if (this.ws.readyState === 1) {
+      this.ws.send(JSON.stringify({ terminal: data }));
+    }
+  }
+
+  startTerminal() {
+    hb.log(`[${this.user.username}]`, 'Terminal session started');
+
+    const shell = fs.existsSync('/bin/bash') ? '/bin/bash' : '/bin/sh';
+
+    this.term = pty.spawn(shell, [], {
+      name: 'xterm-color',
+      cols: 80,
+      rows: 30,
+      cwd: hb.storagePath,
+      env: process.env
+    });
+
+    // send stdout data from the process to the client
+    this.term.on('data', this.send.bind(this));
+
+    // send an error message to the client if the terminal exits
+    this.term.on('exit', (code) => {
+      try {
+        this.send(color.red(`\n\r\n\rTerminal Session Ended\n\r\n\r`));
+      } catch (e) {
+        // the client socket probably closed
+      }
+    });
+  }
+
+  resizeTerminal(size) {
+    if (this.term) {
+      this.term.resize(size.cols, size.rows);
+    }
+  }
+
+  killTerm() {
+    if (this.term) {
+      hb.log(`[${this.user.username}]`, 'Terminal session ended');
+      this.term.kill();
+      this.term.destroy();
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "^5.2.8",
     "@angular/platform-browser-dynamic": "^5.2.8",
     "@angular/router": "^5.2.8",
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.4",
     "@ng-bootstrap/ng-bootstrap": "^1.0.1",
     "@uirouter/angular": "^1.0.0-rc.2",
     "angular2-jwt": "^0.2.3",

--- a/ui/src/app/_services/api.service.ts
+++ b/ui/src/app/_services/api.service.ts
@@ -93,4 +93,16 @@ export class ApiService {
   updateAccessoryLayout(layout) {
     return this.$http.post(`${this.base}/api/accessories/layout`, layout, this.httpOptions);
   }
+
+  dockerGetStartupScript(layout) {
+    return this.$http.get(`${this.base}/api/docker/startup-script`, Object.assign({ responseType: 'text' as 'text' }, this.httpOptions));
+  }
+
+  dockerSaveStartupScript(payload) {
+    return this.$http.post(`${this.base}/api/docker/startup-script`, payload, this.httpOptions);
+  }
+
+  dockerRestartContainer() {
+    return this.$http.put(`${this.base}/api/docker/restart-container`, {}, this.httpOptions);
+  }
 }

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -28,24 +28,36 @@
       <ul class="navbar-nav nav-flex-icons">
         <li class="nav-item waves-effect waves-light" uiSrefActive="active" placement="bottom" ngbTooltip="View Logs" container="body">
           <a class="nav-link" uiSref="logs">
-            <i class="material-icons">&#xE86D;</i>
+            <i class="material-icons">chrome_reader_mode</i>
           </a>
         </li>
         <li class="nav-item waves-effect waves-light" uiSrefActive="active" placement="bottom" ngbTooltip="User Accounts" container="body" *ngIf="$auth.user.admin">
           <a class="nav-link" uiSref="users">
-            <i class="material-icons">&#xE8D3;</i>
+            <i class="material-icons">supervisor_account</i>
           </a>
         </li>
         <li class="nav-item waves-effect waves-light" uiSrefActive="active" placement="bottom" ngbTooltip="Restart" container="body">
           <a class="nav-link" uiSref="restart">
-            <i class="material-icons">&#xE8AC;</i>
+            <i class="material-icons">power_settings_new</i>
           </a>
         </li>
         <li class="nav-item waves-effect waves-light" uiSrefActive="active" placement="bottom" ngbTooltip="Logout" container="body" *ngIf="$auth.formAuth">
           <a class="nav-link" (click)="$auth.logout()">
-            <i class="material-icons">&#xE879;</i>
+            <i class="material-icons">exit_to_app</i>
           </a>
         </li>
+
+        <li class="nav-item dropdown" *ngIf="$auth.env.runningInDocker && $auth.user.admin">
+          <a class="nav-link dropdown-toggle waves-effect waves-light" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <i class="fab fa-docker"></i>
+          </a>
+          <div class="dropdown-menu dropdown-menu-right dropdown-info">
+            <a class="dropdown-item waves-effect waves-light" uiSref="docker-terminal">Terminal</a>
+            <a class="dropdown-item waves-effect waves-light" uiSref="docker-startup-script" >Startup Script</a>
+            <a class="dropdown-item waves-effect waves-light" uiSref="docker-restart-container">Restart Container</a>
+          </div>
+        </li>
+
       </ul>
     </div>
   </nav>

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -18,6 +18,10 @@ import { PluginService } from './_services/plugin.service';
 import { AuthService } from './_services/auth.service';
 import { AuthHttpInterceptor } from './_services/http.service';
 
+import { SpinnerModule } from './spinner/spinner.module';
+import { AccessoriesModule } from './accessories/accessories.module';
+import { DockerToolsModule } from './docker-tools/docker-tools.module';
+
 import { AppComponent } from './app.component';
 import { StatusComponent, StatusStates } from './status/status.component';
 import { PluginsComponent, PluginStates } from './plugins/plugins.component';
@@ -30,11 +34,7 @@ import { UsersAddComponent } from './users/users.add.component';
 import { UsersEditComponent } from './users/users.edit.component';
 import { RestartComponent, RestartState } from './restart/restart.component';
 import { LoginComponent, LoginStates } from './login/login.component';
-
-import { SpinnerComponent } from './spinner/spinner.component';
 import { ResetComponent, ResetModalComponent } from './reset/reset.component';
-
-import { AccessoriesModule } from './accessories/accessories.module';
 
 @NgModule({
   declarations: [
@@ -44,7 +44,6 @@ import { AccessoriesModule } from './accessories/accessories.module';
     ConfigComponent,
     LogsComponent,
     UsersComponent,
-    SpinnerComponent,
     PluginSearchComponent,
     PluginsManageComponent,
     UsersAddComponent,
@@ -67,6 +66,7 @@ import { AccessoriesModule } from './accessories/accessories.module';
     FormsModule,
     ReactiveFormsModule,
     AceEditorModule,
+    SpinnerModule,
     ToastModule.forRoot(),
     NgbModule.forRoot(),
     UIRouterModule.forRoot({
@@ -84,7 +84,8 @@ import { AccessoriesModule } from './accessories/accessories.module';
       config: routerConfigFn,
       otherwise: '/'
     }),
-    AccessoriesModule
+    AccessoriesModule,
+    DockerToolsModule
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: AuthHttpInterceptor, multi: true },

--- a/ui/src/app/config/config.component.scss
+++ b/ui/src/app/config/config.component.scss
@@ -1,3 +1,0 @@
-#config-editor {
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
-}

--- a/ui/src/app/config/config.component.ts
+++ b/ui/src/app/config/config.component.ts
@@ -10,8 +10,7 @@ import { ApiService } from '../_services/api.service';
 
 @Component({
   selector: 'app-config',
-  templateUrl: './config.component.html',
-  styleUrls: ['./config.component.scss']
+  templateUrl: './config.component.html'
 })
 export class ConfigComponent implements OnInit {
   @Input() homebridgeConfig;

--- a/ui/src/app/docker-tools/docker-tools.module.ts
+++ b/ui/src/app/docker-tools/docker-tools.module.ts
@@ -1,0 +1,34 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { UIRouterModule } from '@uirouter/angular';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { AceEditorModule } from 'ng2-ace-editor';
+
+import { SpinnerModule } from '../spinner/spinner.module';
+
+import { StartupScriptEditorComponent, StartupScriptEditorStates } from './startup-script-editor/startup-script-editor.component';
+import { RestartContainerComponent, RestartContainerState} from './restart-container/restart-container.component';
+import { TerminalComponent, TerminalState } from './terminal/terminal.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    NgbModule,
+    AceEditorModule,
+    SpinnerModule,
+    UIRouterModule.forChild({
+      states: [
+        StartupScriptEditorStates,
+        RestartContainerState,
+        TerminalState
+      ]
+    })
+  ],
+  declarations: [
+    StartupScriptEditorComponent,
+    RestartContainerComponent,
+    TerminalComponent
+  ]
+})
+export class DockerToolsModule { }

--- a/ui/src/app/docker-tools/restart-container/restart-container.component.html
+++ b/ui/src/app/docker-tools/restart-container/restart-container.component.html
@@ -1,0 +1,14 @@
+<app-spinner *ngIf="!error"></app-spinner>
+
+<div class="row">
+  <div class="col-md-12 text-center">
+    <h1 class="primary-text"><i class="fab fa-docker"></i></h1>
+    <h3 class="primary-text">Restarting Docker Container</h3>
+    <p class="grey-text" *ngIf="!timeout && !error">Please wait, this page will automatically redirect when the Homebridge is back online.</p>
+    <p class="grey-text" *ngIf="error">{{ error }}</p>
+    <div *ngIf="timeout">
+      <p class="grey-text">Server restart is taking a long time. You may need to bring up the Docker container manually.</p>
+      <p class="primary-text">Make sure you're running the Docker container with <strong>--restart=always</strong></p>
+    </div>
+  </div>
+</div>

--- a/ui/src/app/docker-tools/restart-container/restart-container.component.ts
+++ b/ui/src/app/docker-tools/restart-container/restart-container.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit } from '@angular/core';
+import { TimerObservable } from 'rxjs/observable/TimerObservable';
+import { StateService } from '@uirouter/angular';
+import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+
+import { ApiService } from '../../_services/api.service';
+import { WsService } from '../../_services/ws.service';
+
+@Component({
+  selector: 'app-restart-container',
+  templateUrl: './restart-container.component.html'
+})
+export class RestartContainerComponent implements OnInit {
+  onOpen;
+  onMessage;
+  checkTimeout;
+  checkDelay;
+  resp: any = {};
+  timeout = false;
+  error: any = false;
+
+  constructor(
+    private $api: ApiService,
+    private ws: WsService,
+    public toastr: ToastsManager,
+    private $state: StateService,
+  ) { }
+
+  ngOnInit() {
+    // subscribe to status events
+    if (this.ws.socket.readyState) {
+      this.ws.subscribe('status');
+    }
+
+    this.onOpen = this.ws.open.subscribe(() => {
+      this.ws.subscribe('status');
+    });
+
+    this.$api.dockerRestartContainer().subscribe(
+      data => {
+        this.resp = data;
+        this.checkIfServerUp();
+      },
+      err => {
+        this.error = 'An error occured sending the restart command to the server.';
+        this.toastr.error(`An error occured sending the restart command to the server: ${err.message}`, 'Error');
+      }
+    );
+  }
+
+  checkIfServerUp() {
+    this.checkDelay = TimerObservable.create(10000).subscribe(() => {
+      this.onMessage = this.ws.message.subscribe((data) => {
+        try {
+          data = JSON.parse(data.data);
+
+          if (data.server && data.server.status === 'up') {
+            this.toastr.success('Docker Container Restarted', 'Success');
+            this.$state.go('status');
+          }
+
+        } catch (e) { }
+      });
+    });
+
+    this.checkTimeout = TimerObservable.create(60000).subscribe(() => {
+      this.toastr.warning('The server is taking a long time to come back online', 'Warning', {
+        toastLife: 10000
+      });
+      this.timeout = true;
+    });
+  }
+
+  // tslint:disable-next-line:use-life-cycle-interface
+  ngOnDestroy() {
+    if (this.onOpen) {
+      this.onOpen.unsubscribe();
+    }
+
+    if (this.onMessage) {
+      this.onMessage.unsubscribe();
+    }
+
+    if (this.checkDelay) {
+      this.checkDelay.unsubscribe();
+    }
+
+    if (this.checkTimeout) {
+      this.checkTimeout.unsubscribe();
+    }
+  }
+
+}
+
+export const RestartContainerState = {
+  name: 'docker-restart-container',
+  url: '/docker/restart',
+  component: RestartContainerComponent,
+  data: {
+    requiresAuth: true,
+    requiresAdmin: true
+  }
+};

--- a/ui/src/app/docker-tools/startup-script-editor/startup-script-editor.component.html
+++ b/ui/src/app/docker-tools/startup-script-editor/startup-script-editor.component.html
@@ -1,21 +1,29 @@
 <div class="flex-column d-flex align-items-stretch h-100">
 
   <div class="row">
-    <div class="col-sm-6 d-none d-sm-block">
+    <div class="col-sm-8 d-none d-sm-block">
       <h3 class="primary-text m-0">
-        <span class="d-none d-md-inline">Homebridge</span> Config Editor</h3>
+        <span class="d-none d-md-inline">Docker Container</span> startup.sh</h3>
     </div>
-    <div class="col-sm-6 text-right">
-      <a class="btn btn-elegant waves-effect m-0" [href]="backupConfigHref" download="config.json">Backup</a>
+    <div class="col-sm-4 text-right">
       <button class="btn btn-primary waves-effect m-0" (click)="onSave()">Save</button>
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col-md-12">
+      <div class="alert alert-warning" role="alert">
+       This script will be executed each time the docker container starts.
+       You can use this to install any extra packages your plugins may need such as ffmpeg or libpcap-dev.
+      </div>
     </div>
   </div>
 
   <ace-editor
     class="hb-ace-text-editor align-self-end h-100 mb-3 mt-3"
-    [(text)]="homebridgeConfig"
+    [(text)]="startupScript"
     theme="xcode"
-    mode="json"
+    mode="sh"
     [options]="options"
     [readOnly]="false"
     [autoUpdateContent]="true"

--- a/ui/src/app/docker-tools/startup-script-editor/startup-script-editor.component.ts
+++ b/ui/src/app/docker-tools/startup-script-editor/startup-script-editor.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { StateService } from '@uirouter/angular';
+import { ApiService } from '../../_services/api.service';
+
+import 'brace/theme/xcode';
+import 'brace/mode/sh';
+
+@Component({
+  selector: 'app-startup-script-editor',
+  templateUrl: './startup-script-editor.component.html'
+})
+export class StartupScriptEditorComponent implements OnInit {
+  @Input() startupScript;
+  options: any = { printMargin: false };
+
+  constructor(
+    private $api: ApiService,
+    public toastr: ToastsManager,
+  ) { }
+
+  ngOnInit() {
+  }
+
+  onSave() {
+    // check startup script is using the correct hashbang
+    if (this.startupScript.split('\n')[0].trim() !== '#!/bin/sh') {
+      this.toastr.error('Script must use #!/bin/sh hashbang.', 'Script Error');
+      this.startupScript = '#!/bin/sh\n\n' + this.startupScript;
+      return;
+    }
+
+    this.$api.dockerSaveStartupScript({ script: this.startupScript }).subscribe(
+      data => this.toastr.success('You will need to restart this docker container for the changes to take effect.', 'Startup Script Saved'),
+      err =>  this.toastr.error(err.message, 'Error')
+    );
+  }
+
+}
+
+export function startupScriptStateResolve($api, toastr, $state) {
+  return $api.dockerGetStartupScript().toPromise().catch((err) => {
+    toastr.error(err.message, 'Failed to Load Startup Script');
+    $state.go('status');
+  });
+}
+
+
+export const StartupScriptEditorStates = {
+  name: 'docker-startup-script',
+  url: '/docker/startup-script',
+  component: StartupScriptEditorComponent,
+  resolve: [{
+    token: 'startupScript',
+    deps: [ApiService, ToastsManager, StateService],
+    resolveFn: startupScriptStateResolve
+  }],
+  data: {
+    requiresAuth: true,
+    requiresAdmin: true
+  }
+};

--- a/ui/src/app/docker-tools/terminal/terminal.component.html
+++ b/ui/src/app/docker-tools/terminal/terminal.component.html
@@ -1,0 +1,3 @@
+<div class="flex-column d-flex align-items-stretch h-100">
+  <div id="docker-terminal" class="terminal align-self-end w-100 h-100"></div>
+</div>

--- a/ui/src/app/docker-tools/terminal/terminal.component.ts
+++ b/ui/src/app/docker-tools/terminal/terminal.component.ts
@@ -1,0 +1,119 @@
+import { Component, OnInit, HostListener } from '@angular/core';
+import { Terminal } from 'xterm';
+import * as fit from 'xterm/lib/addons/fit/fit';
+
+import { WsService } from '../../_services/ws.service';
+
+Terminal.applyAddon(fit);
+
+@Component({
+  selector: 'app-docker-terminal',
+  templateUrl: './terminal.component.html'
+})
+export class TerminalComponent implements OnInit {
+  private term = new Terminal();
+  private termTarget: HTMLElement;
+
+  private onOpen;
+  private onMessage;
+  private onError;
+  private onClose;
+
+  constructor(private ws: WsService) { }
+
+  ngOnInit() {
+    // set body bg color
+    window.document.querySelector('body').classList.add(`bg-black`);
+
+    // create terminal
+    this.termTarget = document.getElementById('docker-terminal');
+    this.term.open(this.termTarget);
+    (<any>this.term).fit();
+
+    // subscribe to terminal events
+    if (this.ws.socket.readyState) {
+      this.ws.subscribe('terminal');
+      this.startTerminal();
+    }
+
+    this.onOpen = this.ws.open.subscribe(() => {
+      this.ws.subscribe('terminal');
+      this.startTerminal();
+    });
+
+    this.onMessage = this.ws.message.subscribe((data) => {
+      try {
+        data = JSON.parse(data.data);
+        if (data.terminal) {
+          this.term.write(data.terminal);
+        }
+      } catch (e) { }
+    });
+
+    // handle resize events
+    this.term.on('resize', (size) => {
+      this.resizeTerminal(size);
+    });
+
+    // handle data events
+    this.term.on('data', (data) => {
+      this.ws.send({ terminal: { data: data } });
+    });
+
+    this.onClose = this.ws.close.subscribe(() => {
+      this.term.reset();
+      this.term.write('Connection to server lost...');
+    });
+
+    this.onError = this.ws.error.subscribe((err) => {
+      this.term.write('Websocket failed to connect. Is the server running?\n\r');
+    });
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onWindowResize(event) {
+    (<any>this.term).fit();
+  }
+
+  startTerminal() {
+    this.term.reset();
+    this.ws.send({ terminal: { start: true } });
+    this.resizeTerminal({ cols: this.term.cols, rows: this.term.rows });
+    this.term.focus();
+  }
+
+  resizeTerminal(size) {
+    this.ws.send({ terminal: { size: size } });
+  }
+
+  // tslint:disable-next-line:use-life-cycle-interface
+  ngOnDestroy() {
+    // unset body bg color
+    window.document.querySelector('body').classList.remove(`bg-black`);
+
+    try {
+      // unsubscribe from log events
+      this.ws.unsubscribe('terminal');
+
+      // unsubscribe listeners
+      this.onOpen.unsubscribe();
+      this.onMessage.unsubscribe();
+      this.onError.unsubscribe();
+      this.onClose.unsubscribe();
+
+      // destroy the terminal
+      this.term.destroy();
+    } catch (e) { }
+  }
+
+}
+
+export const TerminalState = {
+  name: 'docker-terminal',
+  url: '/docker/terminal',
+  component: TerminalComponent,
+  data: {
+    requiresAuth: true,
+    requiresAdmin: true
+  }
+};

--- a/ui/src/app/spinner/spinner.module.ts
+++ b/ui/src/app/spinner/spinner.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SpinnerComponent } from './spinner.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    SpinnerComponent
+  ],
+  exports: [
+    SpinnerComponent
+  ]
+})
+export class SpinnerModule { }

--- a/ui/src/app/status/status.component.html
+++ b/ui/src/app/status/status.component.html
@@ -190,11 +190,11 @@
       -
     </small>
     <small>
-      {{ $auth.env.packageName }} v{{ $auth.env.packageVersion }}
+      <a class="grey-text" target="_blank" href="https://github.com/oznu/homebridge-config-ui-x">{{ $auth.env.packageName }} v{{ $auth.env.packageVersion }}</a>
       -
     </small>
     <small>
-      node.js {{ $auth.env.nodeVersion }}
+      <a class="grey-text" target="_blank" href="https://nodejs.org">node.js {{ $auth.env.nodeVersion }}</a>
     </small>
   </div>
 </div>

--- a/ui/src/app/status/status.component.ts
+++ b/ui/src/app/status/status.component.ts
@@ -34,7 +34,7 @@ export class StatusComponent implements OnInit {
   constructor(
     private ws: WsService,
     public $auth: AuthService,
-    private $plugin: PluginService,
+    public $plugin: PluginService,
     private $api: ApiService,
     public toastr: ToastsManager,
     ) {}

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -3,8 +3,11 @@
 $image-path: '../../node_modules/mdbootstrap/img/';
 $roboto-font-path: '../../node_modules/mdbootstrap/font/roboto/';
 $material-design-icons-font-path: '../../node_modules/material-design-icons-iconfont/dist/fonts/';
+$fa-font-path:'../../node_modules/@fortawesome/fontawesome-free-webfonts/webfonts';
 
 @import "~material-design-icons-iconfont/dist/material-design-icons";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fontawesome.scss";
+@import "~@fortawesome/fontawesome-free-webfonts/scss/fa-brands.scss";
 @import "~bootstrap/scss/bootstrap";
 @import "~mdbootstrap/scss/mdb";
 
@@ -87,7 +90,11 @@ body {
 }
 
 .bg-blue {
-    background-color: #1976d2 !important;
+  background-color: #1976d2 !important;
+}
+
+.bg-black {
+  background-color: #000000 !important;
 }
 
 .card .card-text {
@@ -102,6 +109,10 @@ body {
 
 .dropdown-toggle::after {
     display:none
+}
+
+.hb-ace-text-editor {
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
 }
 
 .status-circle {


### PR DESCRIPTION
This adds some features just for users of the [oznu/docker-homebridge](https://github.com/oznu/docker-homebridge) docker image.

- Ability to edit the `startup.sh` script from the Homebridge UI. This makes it easier for Synology DSM users to edit the file since you can't edit .sh files from the DSM GUI.

- Ability to restart the entire docker container (the docker run flag `--restart=always` must be enabled for this to work).

- Ability to connect to the container terminal shell. This is not necessary a Docker-specific, however it's only being activated when Homebridge is running in the [oznu/homebridge](https://github.com/oznu/docker-homebridge) image for now. This might become an *opt-in* feature for other users later.