### PR TITLE
Graceful shutdown of homebridge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ class HomebridgeConfigUi {
     this.log(`Spawning homebridge-config-ui-x with PID`, ui.pid);
 
     ui.on('close', () => {
-      process.exit(1);
+      process.kill(process.pid, 'SIGTERM');
     });
 
     ui.on('error', (err) => { });

--- a/src/modules/server/server.service.ts
+++ b/src/modules/server/server.service.ts
@@ -38,7 +38,7 @@ export class ServerService {
         });
       } else {
         this.logger.log(`No restart command defined, killing process...`);
-        process.exit(1);
+        process.kill(process.pid, 'SIGTERM');
       }
     }, 500);
   }


### PR DESCRIPTION
Termintate the homebridge process by sending it a SIGTERM signal, instead of bluntly exiting NodeJS.  Homebridge catches this signal, allowing plugins to do their cleanup, before calling `process.exit()`.

Tested on macOS for both fork and noFork setup.  I'm not sure if anything else would be needed for standalone mode.