### PR TITLE
Disabled autocapitalize for username field on mobile browsers

### DIFF
--- a/ui/src/app/core/auth/login/login.component.html
+++ b/ui/src/app/core/auth/login/login.component.html
@@ -7,7 +7,7 @@
 
       <div class="md-form">
         <i class="material-icons prefix grey-text">&#xE85E;</i>
-        <input formControlName="username" type="text" id="form-username" autofocus autocomplete="username" tabindex="1"
+        <input formControlName="username" type="text" id="form-username" autofocus autocomplete="username" autocapitalize="none" tabindex="1"
           class="form-control pl-0 pr-0" [ngClass]="{
             'is-invalid': form.controls.username.dirty && form.controls.username.errors
           }">

--- a/ui/src/app/modules/users/users-add/users-add.component.html
+++ b/ui/src/app/modules/users/users-add/users-add.component.html
@@ -7,7 +7,7 @@
       <div class="md-form">
         <i class="material-icons prefix grey-text">&#xE85E;</i>
         <input formControlName="username" [attr.disabled]="(page.title === 'users.title_edit_user') ? true : null" type="text"
-          id="form-username" autocomplete="off" class="form-control pl-0 pr-0">
+          id="form-username" autocomplete="off" autocapitalize="none" class="form-control pl-0 pr-0">
         <label for="form-username" [ngClass]="{'active': page.title === 'users.title_edit_user'}" [translate]="'users.label_username'">Username</label>
       </div>
 

--- a/ui/src/app/modules/users/users-edit/users-edit.component.html
+++ b/ui/src/app/modules/users/users-edit/users-edit.component.html
@@ -7,7 +7,7 @@
       <div class="md-form">
         <i class="material-icons prefix grey-text">&#xE85E;</i>
         <input formControlName="username" [attr.disabled]="(page.title === 'users.title_edit_user') ? true : null" type="text"
-          id="form-username" autocomplete="off" class="form-control pl-0 pr-0">
+          id="form-username" autocomplete="off" autocapitalize="none" class="form-control pl-0 pr-0">
         <label for="form-username" [ngClass]="{'active': page.title === 'users.title_edit_user'}" [translate]="'users.label_username'">Username</label>
       </div>
 


### PR DESCRIPTION
The username is case sensitive. Since the default username is `admin` and most people probably stick with it, it is annoying that mobile browsers automatically capitalize the first letter in the login username input field. This pull request adds the `autocapitalize="none"` property which disables such behavior.