### PR TITLE
add "latestReleaseDate" property to HomebrigePlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ yarn.lock
 # dotenv environment variables file
 .env
 .DS_Store
+
+# npm generated files
+package-lock.json
+ui/package-lock.json

--- a/package.json
+++ b/package.json
@@ -61,12 +61,14 @@
     "class-transformer": "^0.2.3",
     "class-validator": "^0.9.1",
     "commander": "^2.20.0",
+    "dayjs": "^1.8.15",
     "fastify": "^2.4.1",
     "fastify-static": "^2.4.0",
     "node-pty-prebuilt-multiarch": "0.9.0-beta2",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.5.2",
-    "semver": "^6.1.1"
+    "semver": "^6.1.1",
+    "zone.js": "^0.8.29"
   },
   "devDependencies": {
     "@nestjs/jwt": "^6.1.1",

--- a/ui/src/app/modules/plugins/plugins.component.html
+++ b/ui/src/app/modules/plugins/plugins.component.html
@@ -37,6 +37,7 @@
       </div>
       <h4 class="card-title mb-0" [innerHtml]="plugin.description"></h4>
       <p class="card-text">{{ plugin.name }} v{{ plugin.installedVersion || plugin.latestVersion }}</p>
+      <p class="card-text" *ngIf="plugin.updateAvailable">Latest Release Date: {{ plugin.latestReleaseDate }}</p>
       <div class="d-flex">
         <a class="card-link" target="_blank" *ngIf="plugin.publicPackage" [href]="plugin.links.npm">
           NPM


### PR DESCRIPTION
When a search returns multiple similar looking plugins, display the
latestReleaseDate might help people choose which plugin to use

add package-lock.json for server side and ui because this file is auto-generated
by npm, thus no need to include it in version control


**Known Issue**
__ latestReleaseDate__ is always shown even for installed plugin, but for installed plugins, package.json is read locally which does not have "date" property.

adding *ngIf="!plugin.installedVersion" does not hide it.

But ideally, we could fetch the date from npmjs.com response