### PR TITLE
homebridge-ring component tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ yarn.lock
 # dotenv environment variables file
 .env
 .DS_Store
+
+# webstorm/intellij
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-config-ui-x",
-  "version": "4.7.1-test.24",
+  "version": "4.7.1-test.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4406,12 +4406,6 @@
           "dev": true
         }
       }
-    },
-    "node-machine-id": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
-      "dev": true
     },
     "node-pty-prebuilt-multiarch": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "concurrently": "^5.0.2",
     "dotenv": "^8.2.0",
     "lodash": "^4.17.15",
-    "node-machine-id": "^1.1.12",
     "nodemon": "^2.0.2",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
@@ -106,7 +105,6 @@
     "tsconfig-paths": "^3.9.0",
     "tslint": "^5.20.1",
     "typescript": "3.6.4",
-    "uuid": "^3.4.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
     "webpack-node-externals": "^1.7.2"

--- a/src/modules/plugins/custom-plugins/homebridge-ring/homebridge-ring.service.ts
+++ b/src/modules/plugins/custom-plugins/homebridge-ring/homebridge-ring.service.ts
@@ -1,15 +1,10 @@
-import { Injectable, NotFoundException, BadRequestException, UnauthorizedException, HttpException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, HttpException, InternalServerErrorException } from '@nestjs/common';
 import { Logger } from '../../../../core/logger/logger.service';
 import { ConfigService } from '../../../../core/config/config.service';
 import * as rp from 'request-promise-native';
-import { machineId } from 'node-machine-id';
-import * as generateRandomUuid from 'uuid/v4';
-import * as generateUuidFromNamespace from 'uuid/v5';
 
 @Injectable()
 export class HomebridgeRingService {
-  private uuidNamespace = 'e53ffdc0-e91d-4ce1-bec2-df939d94739c';
-
   constructor(
     private configService: ConfigService,
     private logger: Logger,
@@ -33,7 +28,6 @@ export class HomebridgeRingService {
           grant_type: 'password',
           password: credentials.password,
           username: credentials.email,
-          hardware_id: await this.getHardwareId(),
         },
       });
     } catch (e) {
@@ -49,18 +43,4 @@ export class HomebridgeRingService {
       }
     }
   }
-
-  generateUuid(seed?: string) {
-    if (seed) {
-      return generateUuidFromNamespace(seed, this.uuidNamespace);
-    }
-
-    return generateRandomUuid();
-  }
-
-  async getHardwareId() {
-    const id = await machineId();
-    return this.generateUuid(id);
-  }
-
 }

--- a/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
+++ b/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
@@ -8,11 +8,6 @@
   </div>
 
   <div class="modal-body">
-    <div class="mt-3">
-      <markdown hrefTargetBlank class="plugin-md" [data]="schema.headerDisplay" *ngIf="schema.headerDisplay">
-      </markdown>
-    </div>
-
     <div *ngIf="!pluginConfig?.refreshToken && !(pluginConfig?.email && pluginConfig?.password)">
 
       <div class="d-flex justify-content-center">
@@ -21,31 +16,33 @@
             <h4 class="text-center primary-text mb-3"
               translate="plugins.settings.custom.homebridge-gsh.label_link_account"></h4>
 
-            <div [hidden]="doingLogin">
-              <div class="form-group" *ngIf="!twoFactorRequired">
-                <label for="ringAccountEmail">Ring Account Email</label>
-                <input formControlName="email" type="email" class="form-control" id="ringAccountEmail"
-                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
-              </div>
-              <div class="form-group" *ngIf="!twoFactorRequired">
-                <label for="ringAccountPassword">Ring Account Password</label>
-                <input formControlName="password" type="password" class="form-control" id="ringAccountPassword"
-                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
-                <small id="ringAccountPasswordHelp" class="form-text text-muted">
-                  Your password will not be stored or sent to any third parties apart from ring.com.
-                </small>
-              </div>
+            <div [hidden]="doingLogin" class="card p-3">
+              <ng-container *ngIf="!twoFactorRequired">
+                <div class="form-group">
+                  <label for="ringAccountEmail">Ring Account Email</label>
+                  <input formControlName="email" type="email" class="form-control" id="ringAccountEmail"
+                    autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                </div>
+                <div class="form-group">
+                  <label for="ringAccountPassword">Ring Account Password</label>
+                  <input formControlName="password" type="password" class="form-control" id="ringAccountPassword"
+                    autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                  <small id="ringAccountPasswordHelp" class="form-text text-muted">
+                    Your password will not be stored or sent to any third parties apart from ring.com.
+                  </small>
+                </div>
+              </ng-container>
               <div class="form-group" *ngIf="twoFactorRequired">
                 <label for="ringVerificationCode">Verification Code</label>
                 <input formControlName="twoFactorAuthCode" type="text" class="form-control" id="ringVerificationCode"
                   autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
                 <small id="ringVerificationCodeHelp" class="form-text text-muted">
-                  Please enter the code we sent to {{ phoneLastTwo }}.
+                  Please enter the code sent to phone ending in XX{{ phoneLastTwo }}
                 </small>
               </div>
               <div class="text-center">
                 <div class="text-danger mb-2" *ngIf="loginFailReason">{{ loginFailReason | titlecase }}</div>
-                <button type="button" class="btn btn-primary ml-0" (click)="linkAccount()"
+                <button type="submit" class="btn btn-primary ml-0" (click)="linkAccount()"
                   [disabled]="linkAccountForm.invalid">
                   {{ twoFactorRequired ? 'Verify Code' : 'Get Token' }}
                 </button>
@@ -63,12 +60,16 @@
     </div>
 
     <div class="text-center mt-1" *ngIf="pluginConfig?.refreshToken || (pluginConfig?.email && pluginConfig?.password)">
-      <i class="fas fa-check-circle primary-text" style="font-size:50px;"></i>
-      <h4 class="mt-2" translate="plugins.settings.custom.homebridge-gsh.label_account_linked">
-        Account Linked
-      </h4>
+      <div class="mt-3" *ngIf="!justLinked">
+        <markdown hrefTargetBlank class="plugin-md" [data]="schema.headerDisplay" *ngIf="schema.headerDisplay">
+        </markdown>
+      </div>
 
       <div class="mt-3" *ngIf="justLinked">
+        <i class="fas fa-check-circle primary-text" style="font-size:50px;"></i>
+        <h4 class="mt-2" translate="plugins.settings.custom.homebridge-gsh.label_account_linked">
+          Account Linked
+        </h4>
         <p class="primary-text">
           <strong translate="plugins.settings.custom.homebridge-gsh.message_homebridge_restart_required"></strong>
         </p>

--- a/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
+++ b/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
@@ -16,6 +16,9 @@
             <h4 class="text-center primary-text mb-3"
               translate="plugins.settings.custom.homebridge-gsh.label_link_account"></h4>
 
+            <markdown hrefTargetBlank class="plugin-md" [data]="schema.accountLinkingHeader" *ngIf="schema.accountLinkingHeader">
+            </markdown>
+
             <div [hidden]="doingLogin" class="card p-3">
               <ng-container *ngIf="!twoFactorRequired">
                 <div class="form-group">
@@ -37,7 +40,7 @@
                 <input formControlName="twoFactorAuthCode" type="text" class="form-control" id="ringVerificationCode"
                   autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
                 <small id="ringVerificationCodeHelp" class="form-text text-muted">
-                  Please enter the code sent to phone ending in XX{{ phoneLastTwo }}
+                  Please enter the code sent to phone {{ phoneLastTwo }}
                 </small>
               </div>
               <div class="text-center">

--- a/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.ts
@@ -19,7 +19,6 @@ export class HomebridgeRingComponent implements OnInit {
   public phoneLastTwo: string;
   public doingLogin = false;
 
-  public loaded = false;
   public justLinked = false;
   public pluginConfig;
 
@@ -80,6 +79,7 @@ export class HomebridgeRingComponent implements OnInit {
         await this.saveConfig();
         this.linkAccountForm.reset();
         this.doingLogin = false;
+        this.twoFactorRequired = false;
       },
       (err) => {
         this.doingLogin = false;


### PR DESCRIPTION
Hey @oznu, thanks for getting the new homebridge-ring component in so quickly yesterday! I love the UI and can't wait to get it in the hands of users. 

I did some testing and confirmed that `hardware_id` is _not_ necessary for the token request, so I cleaned up those dependencies

I also tweaked the UI a little bit just to make it flow as seemlessly as possible.  I also put the login components in a `card`, which I think should be the only change needed for dark mode.  

## Initial Flow
![image](https://user-images.githubusercontent.com/3026298/72636280-f2e1b580-391b-11ea-847f-04c2829ff6f4.png)
![image](https://user-images.githubusercontent.com/3026298/72636282-f4ab7900-391b-11ea-959f-170347cf366e.png)
![image](https://user-images.githubusercontent.com/3026298/72636290-f83f0000-391b-11ea-9771-ab2d231746dd.png)

## Opening settings after linked
![image](https://user-images.githubusercontent.com/3026298/72636306-0260fe80-391c-11ea-92de-c45abbdae236.png)
