### PR TITLE
status.services.label_running_on_port

### DIFF
--- a/ui/src/i18n/ru.json
+++ b/ui/src/i18n/ru.json
@@ -195,7 +195,7 @@
     "status.services.label_console": "Консоль",
     "status.services.label_listening_on_port": "Порт: {{port}}",
     "status.services.label_not_running": "Не запущен",
-    "status.services.label_running_on_port": "Бег",
+    "status.services.label_running_on_port": "В сети",
     "status.services.title_services": "Сервисы",
     "status.title_server_status": "Статус сервера",
     "status.uptime.label_days": "Дней",


### PR DESCRIPTION
Translation fix for "status.services.label_running_on_port"