### PR TITLE
Update linux.ts

### DIFF
--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -344,6 +344,7 @@ export class LinuxInstaller {
     const serviceFile = [
       `[Unit]`,
       `Description=${this.hbService.serviceName}`,
+      `Wants=network-online.target`,
       `After=syslog.target network-online.target`,
       '',
       `[Service]`,


### PR DESCRIPTION
Added  "Wants=network-online.target" to the file. This sets a "dependency" that the networking online starts before Homebridge. From "man systemd.unit -  It is a common pattern to include a unit name in both the After= and Requires/Wants= options, in which case the
unit listed will be started before the unit that is configured with these options". In my case my Raspberry Pi sometimes starts homebridge plugins before the network is fully up leading to gethostaddr errors.