### PR TITLE
Set angular option for crossOrigin to "use-credentials" to allow authenticated reverse proxy

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -37,6 +37,7 @@
           },
           "configurations": {
             "production": {
+              "crossOrigin": "use-credentials",
               "budgets": [
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
Tested that this option produces index.html with `crossorigin="use-credentials"` and that it resolves the reverse proxy authentication issue.

Fixes #638