### PR TITLE
Login wallpaper use background-size: cover

### DIFF
--- a/ui/src/app/core/auth/login/login.component.ts
+++ b/ui/src/app/core/auth/login/login.component.ts
@@ -42,7 +42,7 @@ export class LoginComponent implements OnInit {
     const backgroundImageUrl = this.$auth.env.customWallpaperHash ?
       environment.api.base + '/auth/wallpaper/' + this.$auth.env.customWallpaperHash :
       '/assets/snapshot.jpg';
-    this.backgroundStyle = `url('${backgroundImageUrl}') no-repeat center center fixed`;
+    this.backgroundStyle = `url('${backgroundImageUrl}') center/cover`;
   }
 
   async onSubmit({ value, valid }) {


### PR DESCRIPTION
Yes this 1 line PR is just to get the background wallpaper image to use `background-size: cover`. Short and sweet =)

Edit: example screenshots attached on wide display.
![before](https://user-images.githubusercontent.com/4887959/83343549-c453ee00-a2b0-11ea-91c9-87b54d5ee0f0.jpg)
![after](https://user-images.githubusercontent.com/4887959/83343548-c158fd80-a2b0-11ea-90fc-f0b5da693f5b.jpg)