### PR TITLE
Ring login 2fa improvements

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
+++ b/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.html
@@ -37,10 +37,11 @@
               </ng-container>
               <div class="form-group" *ngIf="twoFactorRequired">
                 <label for="ringVerificationCode">Verification Code</label>
-                <input formControlName="twoFactorAuthCode" type="text" class="form-control" id="ringVerificationCode"
-                  autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                <input formControlName="twoFactorAuthCode" type="number" class="form-control" id="ringVerificationCode"
+                  autocomplete="one-time-code" autocorrect="off" autocapitalize="off" spellcheck="false"
+                  inputmode="numeric" pattern="[0-9]*">
                 <small id="ringVerificationCodeHelp" class="form-text text-muted">
-                  Please enter the code sent to phone {{ phoneLastTwo }}
+                  Please enter the code sent to {{ codeSentTo }}
                 </small>
               </div>
               <div class="text-center">

--- a/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/homebridge-ring/homebridge-ring.component.ts
@@ -16,7 +16,7 @@ export class HomebridgeRingComponent implements OnInit {
   public linkAccountForm: FormGroup;
   public loginFailReason: string;
   public twoFactorRequired = false;
-  public phoneLastTwo: string;
+  public codeSentTo: string;
   public doingLogin = false;
 
   public justLinked = false;
@@ -87,7 +87,7 @@ export class HomebridgeRingComponent implements OnInit {
           // 2fa required
           this.twoFactorRequired = true;
           if (err.error && err.error.phone) {
-            this.phoneLastTwo = err.error.phone;
+            this.codeSentTo = err.error.phone;
           }
         } else {
           // other authentication error


### PR DESCRIPTION
## Changes
 - Add `one-time-code` autocomplete to 2fa input
 - Only allow numbers in 2fa input (changes keyboard to numbers only on iOS)
 - Remove `phone` from 2fa messaging as codes can be alternatively be sent to email address

![image](https://user-images.githubusercontent.com/3026298/83771731-7257f300-a637-11ea-9626-a3a0edc160eb.png)
