### PR TITLE
Add Homebridge-honeywell-home-roomsensors to Custom Plugins

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.service.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.service.ts
@@ -14,6 +14,7 @@ export class CustomPluginsService {
   public plugins = {
     'homebridge-gsh': HomebridgeGoogleSmarthomeComponent,
     'homebridge-honeywell-home': HomebridgeHoneywellHomeComponent,
+    'homebridge-honeywell-roomsensors': HomebridgeHoneywellHomeComponent,
     'homebridge-ring': HomebridgeRingComponent,
   };
 


### PR DESCRIPTION
since everything is pretty much the same as homebridge-honeywell-home, I figured this is the only change needed?