### PR TITLE
Update config-editor.component.ts

### DIFF
--- a/ui/src/app/modules/config-editor/config-editor.component.ts
+++ b/ui/src/app/modules/config-editor/config-editor.component.ts
@@ -389,12 +389,12 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
               },
               mdns: {
                 type: 'object',
-                description: 'Tell Homebridge to listen on a specific IP address. This is useful if your server has multiple interfaces.',
+                description: 'Tell Homebridge to listen on a specific interface or IP address. This is useful if your server has multiple interfaces.',
                 required: ['interface'],
                 properties: {
                   interface: {
                     type: 'string',
-                    description: 'The IP address of the interface you want Homebridge to listen on.',
+                    description: 'The interface or IP address of the interface you want Homebridge to listen on.',
                   },
                 },
                 default: { interface: '' },


### PR DESCRIPTION
According to https://github.com/homebridge/homebridge/issues/2632#issuecomment-665399016 it is also possible to define an interface instead of an ip address for the mdns section.

Added this to the description.