### PR TITLE
Workaround to fix login form validation when using autofill on iOS

### DIFF
--- a/ui/src/app/core/auth/login/login.component.html
+++ b/ui/src/app/core/auth/login/login.component.html
@@ -18,7 +18,7 @@
 
         <div class="md-form">
           <i class="fas fa-lock prefix grey-text"></i>
-          <input formControlName="password" type="password" id="form-pass" autocomplete="current-password" tabindex="2"
+          <input #password formControlName="password" type="password" id="form-pass" autocomplete="current-password" tabindex="2"
             class="form-control pl-0 pr-0" [ngClass]="{
             'is-invalid': form.controls.password.dirty && form.controls.password.errors
           }">

--- a/ui/src/app/core/auth/login/login.component.ts
+++ b/ui/src/app/core/auth/login/login.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { FormGroup, Validators, FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
+import { debounceTime } from 'rxjs/operators';
 
 import { AuthService } from '../auth.service';
 import { environment } from '@/environments/environment';
@@ -19,6 +20,9 @@ export class LoginComponent implements OnInit {
   public inProgress = false;
   private targetRoute;
 
+  @ViewChild('password')
+  private passwordRef;
+
   constructor(
     private $router: Router,
     public $auth: AuthService,
@@ -29,6 +33,16 @@ export class LoginComponent implements OnInit {
       username: new FormControl('', [Validators.required]),
       password: new FormControl('', [Validators.required]),
     });
+
+    this.form.valueChanges
+      .pipe(debounceTime(500))
+      .subscribe((changes) => {
+        let passVal = this.passwordRef.nativeElement.value;
+
+        if (passVal !== changes.password) {
+          this.form.controls.password.setValue(passVal);
+        }
+      });
 
     this.targetRoute = window.sessionStorage.getItem('target_route') || '';
     this.setBackground();


### PR DESCRIPTION
Fixes #986. Adds method to detect value change relating to iOS autofill and refresh form validation.