### PR TITLE
Add `-T` command-line option to `hb-service`.

### DIFF
--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -84,6 +84,7 @@ export class HomebridgeServiceHelper {
       .option('-P, --plugin-path <path>', '', (p) => { process.env.UIX_CUSTOM_PLUGIN_PATH = p; this.homebridgeOpts.push('-P', p); })
       .option('-U, --user-storage-path <path>', '', (p) => { this.storagePath = p; this.usingCustomStoragePath = true; })
       .option('-S, --service-name <service name>', 'The name of the homebridge service to install or control', (p) => this.serviceName = p)
+      .option('-T, --no-timestamp', '', () => this.homebridgeOpts.push('-T'))
       .option('--port <port>', 'The port to set to the Homebridge UI when installing as a service', (p) => this.uiPort = parseInt(p, 10))
       .option('--user <user>', 'The user account the Homebridge service will be installed as (Linux, macOS only)', (p) => this.asUser = p)
       .option('--stdout', '', () => this.stdout = true)


### PR DESCRIPTION
As discussed in Discord: to suppress timestamps in the log output.  Useful in combination with `--sdtout` when logging using systemd.

I hope this is OK.  I ran `npm run test:e2e`:
```
Test Suites: 18 passed, 18 total
Tests:       180 passed, 180 total
Snapshots:   0 total
Time:        33.624 s
```