### PR TITLE
handle deep plugin homepage when searching for latest release

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -799,13 +799,13 @@ export class PluginsService {
     }
 
     // make sure the repo is GitHub
-    if (!plugin.links.homepage.match(/https:\/\/github.com/)) {
+    const repoMatch = plugin.links.homepage.match(/https:\/\/github.com\/([^\/]+)\/([^\/#]+)/);
+    if (!repoMatch) {
       throw new NotFoundException();
     }
 
     try {
-      const repo = plugin.links.homepage.split('https://github.com/')[1].split('#readme')[0];
-      const release = (await this.httpService.get(`https://api.github.com/repos/${repo}/releases/latest`).toPromise()).data;
+      const release = (await this.httpService.get(`https://api.github.com/repos/${repoMatch[1]}/${repoMatch[2]}/releases/latest`).toPromise()).data;
       return {
         name: release.name,
         changelog: release.body,


### PR DESCRIPTION
The `homebridge-ring` plugin hasn't been showing the initial release notes before updating for a while now.  Finally took a second to track it down and it looks like it's because my `homepage` url is a little non-standard: https://github.com/dgreif/ring/tree/master/homebridge#homebridge-ring.  Took a more generic approach to your url parsing and look specifically for the user/repo parts of the url using regex.  Still works for homepages with `#readme` (or any other #) at the end