### PR TITLE
Replace :hover with media query to prevent double taps on mobile

### DIFF
--- a/ui/src/app/modules/logs/logs.component.scss
+++ b/ui/src/app/modules/logs/logs.component.scss
@@ -12,9 +12,11 @@
     -o-transition: opacity 200ms ease-in;
     transition: opacity 200ms ease-in;
 
-    &:hover,
-    &:active {
-      opacity: 1;
+    @media (hover: hover) {
+      &:hover,
+      &:active {
+        opacity: 1;
+      }
     }
   }
 }

--- a/ui/src/app/modules/plugins/plugins.component.scss
+++ b/ui/src/app/modules/plugins/plugins.component.scss
@@ -9,12 +9,14 @@
   padding: 10px;
   margin-bottom: 15px;
 
-  &:focus,
-  &:hover {
-    border: 1px solid #000000;
+  
+  @media (hover: hover) {
+    &:hover {
+      border: 1px solid #000000;
+    }
   }
-
   &:focus {
+    border: 1px solid #000000;
     box-shadow: 0 1px 0 0 #000000;
   }
 }

--- a/ui/src/app/modules/status/status.component.scss
+++ b/ui/src/app/modules/status/status.component.scss
@@ -1,8 +1,10 @@
 ::ng-deep {
   a {
     &.grey-text {
-      &:hover {
-        text-decoration: underline;
+      @media (hover: hover) {
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }
@@ -34,10 +36,12 @@ gridster {
 }
 
 .widget-item {
-  &:hover,
-  &:active {
-    .widget-control-button {
-      opacity: 1;
+  @media (hover: hover) {
+    &:hover,
+    &:active {
+      .widget-control-button {
+        opacity: 1;
+      }
     }
   }
 }
@@ -55,9 +59,11 @@ gridster {
   -o-transition: opacity 200ms ease-in;
   transition: opacity 200ms ease-in;
 
-  &:hover,
-  &:active {
-    opacity: 1;
+  @media (hover: hover) {
+    &:hover,
+    &:active {
+      opacity: 1;
+    }
   }
 
   @media (max-width: 1023px) {

--- a/ui/src/app/modules/status/widget-add/widget-add.component.scss
+++ b/ui/src/app/modules/status/widget-add/widget-add.component.scss
@@ -6,10 +6,11 @@
   border-radius: 5px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
   padding: 15px;
-
-  &:hover {
-    .add-widget-label {
-      font-weight: 500;
+  @media (hover: hover) {
+    &:hover {
+      .add-widget-label {
+        font-weight: 500;
+      }
     }
   }
 }

--- a/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.scss
+++ b/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.scss
@@ -5,8 +5,10 @@ table.table-sm td {
 }
 
 .system-info-link {
-  &:hover {
-    text-decoration: underline;
+  @media (hover: hover) {
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/ui/src/scss/base/buttons.scss
+++ b/ui/src/scss/base/buttons.scss
@@ -23,9 +23,11 @@
   width: 47px;
   height: 47px;
 
-  &:hover {
-    -webkit-box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-    box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  @media (hover: hover) {
+    &:hover {
+      -webkit-box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+      box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+    }
   }
 }
 

--- a/ui/src/scss/components/accessories.scss
+++ b/ui/src/scss/components/accessories.scss
@@ -114,10 +114,12 @@
     }
   }
 
-  &:hover,
-  &:active {
-    .manage-accessory-button {
-      opacity: 0.6;
+  @media (hover: hover) {
+    &:hover,
+    &:active {
+      .manage-accessory-button {
+        opacity: 0.6;
+      }
     }
   }
 
@@ -128,10 +130,12 @@
     margin-right: 15px;
     margin-top: 15px;
 
-    &:active,
-    &:hover {
-      opacity: 1;
-      transform: scale(1.2);
+    @media (hover: hover) {
+      &:active,
+      &:hover {
+        opacity: 1;
+        transform: scale(1.2);
+      }
     }
   }
 

--- a/ui/src/scss/themes/themes-dark.scss
+++ b/ui/src/scss/themes/themes-dark.scss
@@ -66,7 +66,11 @@
           background-color: $darkModePrimary;
           border-color: $darkModePrimary;
         }
-        &:hover,
+        @media (hover: hover) {
+          &:hover {
+            border-color: $darkModePrimary !important;
+          }
+        }
         &:focus {
           border-color: $darkModePrimary !important;
         }
@@ -80,8 +84,10 @@
 
       a {
         color: $secondaryBackground;
-        &:hover {
-          text-decoration: underline;
+        @media (hover: hover) {
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
     }
@@ -98,21 +104,29 @@
       &.card-link {
         color: #9e9e9e;
 
-        &:hover {
-          color: $darkModePrimary !important;
+        @media (hover: hover) {
+          &:hover {
+            color: $darkModePrimary !important;
+          }
         }
       }
 
       color: $darkModePrimary;
-      &:hover {
-        text-decoration: underline;
+      
+      @media (hover: hover) {
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
 
     .icon-button {
       cursor: pointer;
-      &:hover {
-        color: $darkModePrimary !important;
+
+      @media (hover: hover) {
+        &:hover {
+          color: $darkModePrimary !important;
+        }
       }
     }
 
@@ -162,7 +176,9 @@
     }
 
     .table-hover tbody tr:hover {
-      color: $darkModePrimary !important;
+      @media (hover: hover) {
+        color: $darkModePrimary !important;
+      }
     }
 
     .table-striped tbody tr:nth-of-type(odd) {
@@ -201,12 +217,14 @@
       color: #999999 !important;
       border-color: #242424 !important;
 
-      &:focus,
-      &:hover {
-        border: 1px solid #242424 !important;
+      @media (hover: hover) {
+        &:hover {
+          border: 1px solid #242424 !important;
+        }
       }
 
       &:focus {
+        border: 1px solid #242424 !important;
         box-shadow: inherit !important;
         color: $darkModePrimary !important;
       }

--- a/ui/src/scss/themes/themes-light.scss
+++ b/ui/src/scss/themes/themes-light.scss
@@ -22,17 +22,21 @@
     a {
       &.card-link {
         color: #000000;
-
-        &:hover {
-          color: $primary !important;
+        
+        @media (hover: hover) {
+          &:hover {
+            color: $primary !important;
+          }
         }
       }
     }
 
     .icon-button {
       cursor: pointer;
-      &:hover {
-        color: $primary !important;
+      @media (hover: hover) {
+        &:hover {
+          color: $primary !important;
+        }
       }
     }
 
@@ -44,7 +48,11 @@
           background-color: $primary;
           border-color: $primary;
         }
-        &:hover,
+        @media (hover: hover) {
+          &:hover {
+            border-color: $primary !important;
+          }
+        }
         &:focus {
           border-color: $primary !important;
         }


### PR DESCRIPTION
https://css-tricks.com/annoying-mobile-double-tap-link-issue/

- :active rules are folded in with hover media query because they are about the pressed state.
- :focus rules are duplicated where needed to ensure styling stays for input fields, etc. 