### PR TITLE
fix: show custom-ui spinner on top of schema forms

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.html
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.html
@@ -12,11 +12,6 @@
       <i class="fa fa-cog fa-spin" style="font-size: 72px;"></i>
     </div>
 
-    <div *ngIf="pluginSpinner"
-      class="loading-overlay text-center primary-text d-flex align-items-center justify-content-center">
-      <i class="fa fa-cog fa-spin" style="font-size: 72px;"></i>
-    </div>
-
     <iframe width="100%" height="1px;" #custompluginui
       sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads allow-forms"
       style="border: 0;">
@@ -42,6 +37,11 @@
           {{ formSubmitButtonLabel }}
         </button>
       </div>
+    </div>
+
+    <div *ngIf="pluginSpinner"
+         class="loading-overlay text-center primary-text d-flex align-items-center justify-content-center">
+      <i class="fa fa-cog fa-spin" style="font-size: 72px;"></i>
     </div>
   </div>
 


### PR DESCRIPTION
The spinner activated by `homebridge.showSpinner()` currently shows up _behind_ any schema forms rendered outside the iframe for custom UIs.  There is no z-index on the overlay, so it's a simple matter of DOM ordering.  Here I'm moving it after the schema form so that it always shows on top.

## Before
![image](https://user-images.githubusercontent.com/3026298/127753674-5e9c8bbe-b84b-4103-8449-4956a5385aaa.png)


## After
![image](https://user-images.githubusercontent.com/3026298/127753670-e12f6cb6-67a1-46a1-a360-002a9e3d8ed8.png)
