### PR TITLE
Fix alignment of light sensor stats

### DIFF
--- a/ui/src/app/core/accessories/types/lightsensor/lightsensor.component.html
+++ b/ui/src/app/core/accessories/types/lightsensor/lightsensor.component.html
@@ -1,7 +1,7 @@
 <div class="accessory-box">
-  <div class="d-flex flex-column h-100 mt-auto">
+  <div class="d-flex flex-column h-100">
     <div [inlineSVG]="'/assets/hap-icons/light.svg'" aria-label="Light Sensor" class="accessory-svg"></div>
-    <div class="accessory-label">{{ service.customName || service.serviceName }}</div>
+    <div class="accessory-label mt-auto">{{ service.customName || service.serviceName }}</div>
     <div class="accessory-label grey-text">{{ service.values.CurrentAmbientLightLevel }} lux</div>
   </div>
 </div>


### PR DESCRIPTION
This pull request moves the class to an element commonly used by other accessories to vertically align the statistics at the bottom.

Before:
![Before](https://user-images.githubusercontent.com/2276355/152252790-38fa995b-b96f-420a-ac2f-7bf9852760b9.png)

After:
![After](https://user-images.githubusercontent.com/2276355/152252798-bd300b73-a238-4ead-8549-6410c5b9e99d.png)

Before short:
![After short](https://user-images.githubusercontent.com/2276355/152253015-2ea6ffd5-4f91-4894-b117-dd97ed5819af.png)

After short:
![Before short](https://user-images.githubusercontent.com/2276355/152253091-dbc7016f-33cb-4bc9-9879-a3d2e3f022b6.png)