### PR TITLE
hb-service support for FreeBSD

### DIFF
--- a/src/bin/platforms/freebsd.ts
+++ b/src/bin/platforms/freebsd.ts
@@ -1,0 +1,312 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra';
+
+import { HomebridgeServiceHelper } from '../hb-service';
+
+export class FreeBSDInstaller {
+  private hbService: HomebridgeServiceHelper;
+
+  constructor(hbService: HomebridgeServiceHelper) {
+    this.hbService = hbService;
+  }
+
+  private get rcServiceName() {
+    return this.hbService.serviceName.toLowerCase();
+  }
+
+  private get rcServicePath() {
+    return path.resolve('/usr/local/etc/rc.d', this.rcServiceName);
+  }
+  
+  /**
+   * Installs the rc service
+   */
+  public async install() {
+    this.checkForRoot();
+    await this.checkUser();
+    this.setupSudo();
+    
+    await this.hbService.portCheck();
+    await this.hbService.storagePathCheck();
+    await this.hbService.configCheck();
+  
+    try {
+      await this.createRCService();
+      await this.enableService();
+      await this.start();
+      await this.hbService.printPostInstallInstructions();
+    } catch (e) {
+      console.error(e.toString());
+      this.hbService.logger('ERROR: Failed Operation', 'fail');
+    }
+  }
+
+  /**
+   * Removes the rc service
+   */
+  public async uninstall() {
+    this.checkForRoot();
+    await this.stop();
+  
+  // try and disable the service
+    await this.disableService();
+
+    try {
+      if (fs.existsSync(this.rcServicePath)) {
+        this.hbService.logger(`Removed ${this.rcServiceName} Service`, 'succeed');
+        fs.unlinkSync(this.rcServicePath);
+      } else {
+        this.hbService.logger(`Could not find installed ${this.rcServiceName} Service.`, 'fail');
+      }
+    } catch (e) {
+      console.error(e.toString());
+      this.hbService.logger('ERROR: Failed Operation', 'fail');
+    }
+  }
+
+  /**
+   * Starts the rc service
+   */
+  public async start() {
+    this.checkForRoot();
+    try {
+      this.hbService.logger(`Starting ${this.rcServiceName} Service...`);
+      child_process.execSync(`service ${this.rcServiceName} start`, { stdio: 'inherit' });
+      this.hbService.logger(`${this.rcServiceName} Started`, 'succeed');
+    } catch (e) {
+      this.hbService.logger(`Failed to start ${this.rcServiceName}`, 'fail');
+    }
+  }
+
+  /**
+   * Stops the rc service
+   */
+  public async stop() {
+    this.checkForRoot();
+    try {
+      this.hbService.logger(`Stopping ${this.rcServiceName} Service...`);
+      child_process.execSync(`service ${this.rcServiceName} stop`, { stdio: 'inherit' });
+      this.hbService.logger(`${this.rcServiceName} Stopped`, 'succeed');
+    } catch (e) {
+      this.hbService.logger(`Failed to stop ${this.rcServiceName}`, 'fail');
+    }
+  }
+
+  /**
+   * Restarts the rc service
+   */
+  public async restart() {
+    this.checkForRoot();
+    try {
+      this.hbService.logger(`Restarting ${this.rcServiceName} Service...`);
+      child_process.execSync(`service ${this.rcServiceName} restart`, { stdio: 'inherit' });
+      this.hbService.logger(`${this.rcServiceName} Restarted`, 'succeed');
+    } catch (e) {
+      this.hbService.logger(`Failed to restart ${this.rcServiceName}`, 'fail');
+    }
+  }
+
+  /**
+   * Rebuilds the Node.js modules for Homebridge Config UI X
+   */
+  public async rebuild(all = false) {
+    try {
+      this.checkForRoot();
+      const npmGlobalPath = child_process.execSync('/bin/echo -n "$(npm --no-update-notifier -g prefix)/lib/node_modules"').toString('utf8');
+      const targetNodeVersion = child_process.execSync('node -v').toString('utf8').trim();
+  
+      child_process.execSync('npm rebuild --unsafe-perm', {
+        cwd: process.env.UIX_BASE_PATH,
+        stdio: 'inherit',
+      });
+  
+      if (all === true) {
+        // rebuild all modules
+        try {
+          child_process.execSync('npm rebuild --unsafe-perm', {
+            cwd: npmGlobalPath,
+            stdio: 'inherit',
+          });
+        } catch (e) {
+          this.hbService.logger('Could not rebuild all modules - check Homebridge logs.', 'warn');
+        }
+      }
+  
+      this.hbService.logger(`Rebuilt modules in ${process.env.UIX_BASE_PATH} for Node.js ${targetNodeVersion}.`, 'succeed');
+    } catch (e) {
+      console.error(e.toString());
+      this.hbService.logger('ERROR: Failed Operation', 'fail');
+    }
+  }
+
+  /**
+   * Returns the users uid and gid.
+   */
+  public async getId(): Promise<{ uid: number; gid: number }> {
+    if (process.getuid() === 0 && this.hbService.asUser || process.env.SUDO_USER) {
+      const uid = child_process.execSync(`id -u ${this.hbService.asUser || process.env.SUDO_USER}`).toString('utf8');
+      const gid = child_process.execSync(`id -g ${this.hbService.asUser || process.env.SUDO_USER}`).toString('utf8');
+      return {
+        uid: parseInt(uid, 10),
+        gid: parseInt(gid, 10),
+      };
+    } else {
+      return {
+        uid: os.userInfo().uid,
+        gid: os.userInfo().gid,
+      };
+    }
+  }
+
+  /**
+   * Returns the pid of the process running on the defined port
+   */
+  public getPidOfPort(port: number) {
+    try {
+      return child_process.execSync(`sockstat -P tcp -p ${port} -l -q 2> /dev/null | awk '{print $3}' | head -n 1`).toString('utf8').trim();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Enables rc service for autostart
+   */
+  private async enableService() {
+    try {
+      child_process.execSync(`sysrc ${this.rcServiceName}_enable="YES" 2> /dev/null`);
+    } catch (e) {
+      this.hbService.logger(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"YES\"`, 'warn');
+    }
+  }
+
+  /**
+   * Disables rc service for autostart
+   */
+  private async disableService() {
+    try {
+      child_process.execSync(`sysrc ${this.rcServiceName}_enable="˜NO" 2> /dev/null`);
+    } catch (e) {
+      this.hbService.logger(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"NO\"`, 'warn');
+    }
+  }
+  
+  /**
+   * Check the command is being run as root and we can detect the user
+   */
+  private checkForRoot() {
+    if (process.getuid() !== 0) {
+      this.hbService.logger('ERROR: This command must be executed using sudo on FreeBSD', 'fail');
+      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action}`, 'fail');
+      process.exit(1);
+    }
+    if (!process.env.SUDO_USER && !this.hbService.asUser) {
+      this.hbService.logger('ERROR: Could not detect user. Pass in the user you want to run Homebridge as using the --user flag eg.', 'fail');
+      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action} --user your-user`, 'fail');
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Checks the user exists
+   */
+  private async checkUser() {
+    try {
+      // check if user exists
+      child_process.execSync(`id ${this.hbService.asUser} 2> /dev/null`);
+    } catch (e) {
+      // if not create the user
+      child_process.execSync(`pw useradd -q -n ${this.hbService.asUser} -s /usr/sbin/nologin 2> /dev/null`);
+      this.hbService.logger(`Created service user: ${this.hbService.asUser}`, 'info');
+    }
+  }
+
+  // TODO: shutdown doesn't exist in jails. Require jailutils, sysctl security.jail.jailed to check, jkill to restart
+  /**
+   * Allows the homebridge user to shutdown and restart the server from the UI
+   * There is no need for full sudo access when running using hb-service
+   */
+  private setupSudo() {
+    try {
+      const npmPath = child_process.execSync('which npm').toString('utf8').trim();
+      const shutdownPath = child_process.execSync('which shutdown').toString('utf8').trim();
+      const sudoersEntry = `${this.hbService.asUser}    ALL=(ALL) NOPASSWD:SETENV: ${shutdownPath}, ${npmPath}, /usr/local/bin/npm, /usr/sbin/service, /usr/bin/tail`;
+    
+      // check if the sudoers file already contains the entry
+      const sudoers = fs.readFileSync('/usr/local/etc/sudoers', 'utf-8');
+      if (sudoers.includes(sudoersEntry)) {
+        return;
+      }
+    
+      // grant the user restricted sudo privileges to /sbin/shutdown
+      child_process.execSync(`echo '${sudoersEntry}' | sudo EDITOR='tee -a' visudo`);
+    } catch (e) {
+      this.hbService.logger('WARNING: Failed to setup /etc/sudoers, you may not be able to shutdown/restart your server from the Homebridge UI.', 'warn');
+    }
+  }
+
+  /**
+   * Update Node.js
+   */
+  public async updateNodejs(job: { target: string; rebuild: boolean }) {
+    this.hbService.logger('Update Node.js using pkg manually.', 'fail');
+      process.exit(1);
+  }
+
+  /**
+   * Create the rc service script
+   */
+  private async createRCService() {
+    const nodePath = child_process.execSync('which node').toString('utf8').trim();
+    const rcFileContents = [
+      '#!/bin/sh',
+      '#',
+      '# PROVIDE: ' + this.rcServiceName,
+      '# REQUIRE: NETWORKING SYSLOG',
+      '# KEYWORD: shutdown',
+      '#',
+      '# Add the following lines to /etc/rc.conf to enable ' + this.rcServiceName + ':',
+      '#',
+      '#' + this.rcServiceName + '_enable="YES"',
+      '',
+      '. /etc/rc.subr',
+      '',
+      'name="' + this.rcServiceName + '"',
+      'rcvar="' + this.rcServiceName + '_enable"',
+      '',
+      'load_rc_config $name',
+      '',
+      ': ${' + this.rcServiceName + '_user:="' + this.hbService.asUser + '"}',
+      ': ${' + this.rcServiceName + '_enable:="NO"}',
+      ': ${' + this.rcServiceName + '_facility:="daemon"}',
+      ': ${' + this.rcServiceName + '_priority:="debug"}',
+      ': ${' + this.rcServiceName + '_storage_path:="' + this.hbService.storagePath + '"}',
+      '',
+      'command="/usr/local/bin/${name}"',
+      'procname="' + nodePath + '"',
+      'home="$(eval echo ~${' + this.rcServiceName + '_user})"',
+      '',
+      'pidfile="/var/run/${name}.pid"',
+      '',
+      'start_cmd="${name}_start"',
+      '',
+      this.rcServiceName + '_start() {',
+      ' /usr/sbin/daemon -S -l ${' + this.rcServiceName + '_facility} -s ${' + this.rcServiceName + '_priority} \\',
+      '   -u ${' + this.rcServiceName + '_user} -p ${pidfile} -t ' + this.rcServiceName + ' \\',
+      '   /usr/bin/env -i \\',
+      '   "HOME=${home}" \\',
+      '   "PATH=/usr/local/bin:${PATH}" \\',
+      '   "UIX_STORAGE_PATH=${' + this.rcServiceName + '_storage_path}" \\',
+      '   $command \\',
+      '   -U "${' + this.rcServiceName + '_storage_path}"',
+      '}',
+      '',
+      'run_rc_command "$1"',
+    ].filter(x => x).join('\n');
+  
+    await fs.outputFile(this.rcServicePath, rcFileContents);
+    await fs.chmod(this.rcServicePath, '755');
+  }
+}

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -49,7 +49,8 @@ export class ConfigService {
   public runningInSynologyPackage = Boolean(process.env.HOMEBRIDGE_SYNOLOGY_PACKAGE === '1');
   public runningInPackageMode = Boolean(process.env.HOMEBRIDGE_APT_PACKAGE === '1');
   public runningInLinux = (!this.runningInDocker && !this.runningInSynologyPackage && !this.runningInPackageMode && os.platform() === 'linux');
-  public canShutdownRestartHost = (this.runningInLinux || process.env.UIX_CAN_SHUTDOWN_RESTART_HOST === '1');
+  public runningInFreeBSD = (os.platform() === 'freebsd');
+  public canShutdownRestartHost = (this.runningInLinux || this.runningInFreeBSD || process.env.UIX_CAN_SHUTDOWN_RESTART_HOST === '1');
   public enableTerminalAccess = this.runningInDocker || this.runningInSynologyPackage || this.runningInPackageMode || Boolean(process.env.HOMEBRIDGE_CONFIG_UI_TERMINAL === '1');
   public usePnpm = (process.env.UIX_USE_PNPM === '1');
 
@@ -203,6 +204,7 @@ export class ConfigService {
         runningInSynologyPackage: this.runningInSynologyPackage,
         runningInPackageMode: this.runningInPackageMode,
         runningInLinux: this.runningInLinux,
+        runningInFreeBSD: this.runningInFreeBSD,
         runningOnRaspberryPi: this.runningOnRaspberryPi,
         canShutdownRestartHost: this.canShutdownRestartHost,
         dockerOfflineUpdate: this.dockerOfflineUpdate,

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -19,6 +19,7 @@ interface EnvInterface {
   packageVersion: string;
   runningInDocker: boolean;
   runningInLinux: boolean;
+  runningInFreeBSD: boolean;
   runningInSynologyPackage: boolean;
   runningInPackageMode: boolean;
   runningOnRaspberryPi: boolean;

--- a/ui/src/app/modules/settings/settings.component.ts
+++ b/ui/src/app/modules/settings/settings.component.ts
@@ -127,6 +127,7 @@ export class SettingsComponent implements OnInit {
       if (semver.gte(homebridgePackage.installedVersion, '1.4.0-beta.0', { includePrerelease: true })) {
         if (
           this.$settings.env.runningInLinux ||
+          this.$settings.env.runningInFreeBSD ||
           this.$settings.env.runningInDocker ||
           this.$settings.env.runningInSynologyPackage ||
           this.$settings.env.runningInPackageMode


### PR DESCRIPTION
Following up to the offer in [issue 784](https://github.com/oznu/homebridge-config-ui-x/issues/784#issuecomment-662377146), this patch is the start of FreeBSD support for hb-service.

There's a lot of features in here to get working and a few aren't complete, but now seemed like a good starting point for discussion and feedback and work can continue in this PR.

- The use of daemon sets up logging a bit differently than expected.
- sudo should probably default to true.
- shutdown doesn't work in a jail, so another solution is needed. (There's a TODO comment for this.)
- I didn't actually get Avahi working, although it should be possible.
- Restart from the UI just does a kill for now.
- hb-service update-node just displays a message for now.

The rc service script is based on work by Stefan Bethke, who responded that the blog post from which it came is CC0.