### PR TITLE
Prevent tooltip from displaying after Node.js modal

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -52,7 +52,7 @@
     </a>
     <a href="javascript:void(0)" class="card-link" *ngIf="plugin.updateAvailable" (click)="$plugin.updatePlugin(plugin)"
        placement="bottom" ngbTooltip="{{'plugins.tooltip_update_plugin_to' | translate:plugin }}" container="body"
-       openDelay="150" [translate]="'plugins.button_update'">
+       openDelay="150" [translate]="'plugins.button_update'" triggers="hover">
       {{ 'plugins.button_update' | translate | uppercase }}
     </a>
     <a href="javascript:void(0)" class="card-link" *ngIf="!plugin.installedVersion"


### PR DESCRIPTION
## :recycle: Current situation

If `node-update-required-modal.component` is displayed before updating a plug-in the tooltip will persist:

<img width="1234" alt="Screenshot 2023-10-24 at 18 59 26" src="https://github.com/homebridge/homebridge-config-ui-x/assets/2276355/25452698-8eae-4fb7-9174-03ed4060381e">

## :bulb: Proposed solution

Restrict the tooltip to on hover, https://github.com/ng-bootstrap/ng-bootstrap/issues/3517 appears to outline the issue.