### PR TITLE
Fix for unable to update nodejs version (see #1599)

### DIFF
--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -429,7 +429,7 @@ export class LinuxInstaller extends BasePlatform {
       }
 
       // update repo
-      child_process.execSync(`echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${majorVersion}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`, {
+      child_process.execSync(`echo "deb [signed-by=/etc/apt/keyrings/nodes] https://deb.nodesource.com/node_${majorVersion}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`, {
         stdio: 'inherit',
       });
 


### PR DESCRIPTION
…ridge/homebridge-config-ui-x)

## :recycle: Current situation

Line 420 executes:

`curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/nodes`

so the key is stored in /etc/apt/keyrings/nodes

In line 426 the old file "rm -f /usr/share/keyrings/nodesource.gpg" is deleted

However line 432 hasn't been updated, as it still refers to this old file, which is now deleted:

`echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${majorVersion}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`

## :bulb: Proposed solution

Line 432 should be changed to refer to /etc/apt/keyrings/nodes:

`echo "deb [signed-by=/etc/apt/keyrings/nodes] https://deb.nodesource.com/node_${majorVersion}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list`

## :gear: Release Notes

This pull request makes a simple change to update the reference to the key file in the /etc/apt/sources.list.d/nodesource.list
Without this nodejs cannot be updated properly.
