### PR TITLE
Plugins - dropdown menu placement

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -90,7 +90,7 @@
 
       </ng-container>
 
-      <span ngbDropdown class="d-inline-block ml-3">
+      <span ngbDropdown placement="bottom-right top-right" class="d-inline-block ml-3">
         <a href="javascript:void(0)" class="card-link grey-text" aria-label="Plugin actions drop down menu"
            ngbDropdownToggle>
           <span class="card-link">


### PR DESCRIPTION
Default: bottom-right
If it doesn't fit: top-right