### PR TITLE
layout fix

### DIFF
--- a/ui/src/app/modules/plugins/plugins.component.scss
+++ b/ui/src/app/modules/plugins/plugins.component.scss
@@ -35,6 +35,6 @@
   width: calc(1 / 2 * 100% - (1 - 1 / 3) * 10px);
 
   @media only screen and (max-width: 991px) {
-    width: calc(100% - (1 - 1 / 3) * 10px);
+    width: 100%;
   }
 }


### PR DESCRIPTION
As you can see, the margins are not equal in the mobile view.

Before:
<img width="178" alt="Zrzut ekranu 2023-11-11 o 23 42 14" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/9155effc-f3ae-411d-9d60-ec08bb153a21">

After:
<img width="202" alt="Zrzut ekranu 2023-11-11 o 23 45 52" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/1a333d3f-d3ed-438b-8192-41868eecbd01">
