### PR TITLE
Small fix in footer links

### DIFF
--- a/ui/src/app/modules/status/status.component.html
+++ b/ui/src/app/modules/status/status.component.html
@@ -38,12 +38,10 @@
         &copy; 2023
         &middot;
         <a class="grey-text" target="_blank" rel="noopener noreferrer" href="https://github.com/homebridge">
-          Homebridge v{{ $settings.env.homebridgeVersion }}
-        </a>
+          Homebridge v{{ $settings.env.homebridgeVersion }}</a>
         &middot;
         <a class="grey-text" target="_blank" rel="noopener noreferrer" href="https://github.com/homebridge/homebridge-config-ui-x">
-          UI v{{ $settings.env.packageVersion }}
-        </a>
+          UI v{{ $settings.env.packageVersion }}</a>
         &middot;
         UI developed by
         <a class="grey-text" target="_blank" rel="noopener noreferrer" href="https://github.com/oznu">oznu</a>


### PR DESCRIPTION
From:
<img width="203" alt="Zrzut ekranu 2023-11-16 o 13 24 08" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/fa18a496-e53e-4a2f-8021-bff9875c4af4">


<img width="213" alt="Zrzut ekranu 2023-11-16 o 13 24 00" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/2d857562-9124-45a9-82b8-574af013ad70">

(Links included spaces)
