### PR TITLE
not installed plugin icon

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -7,7 +7,7 @@
         <i class="far fa-fw fa-circle-check"></i> {{ 'plugins.status_installed' | translate }}
       </p>
       <p class="mb-0 grey-text" *ngIf="!plugin.installedVersion">
-        <i class="far fa-fw fa-circle-xmark"></i> {{ 'plugins.status_not_installed' | translate }}
+        <i class="far fa-fw fa-circle-arrow-down"></i> {{ 'plugins.status_not_installed' | translate }}
       </p>
       <p class="mb-0 primary-text" *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable && !plugin.disabled">
         <i class="far fa-fw fa-arrow-alt-circle-up"></i> {{ 'plugins.status_update_available' | translate }}

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -7,7 +7,7 @@
         <i class="far fa-fw fa-circle-check"></i> {{ 'plugins.status_installed' | translate }}
       </p>
       <p class="mb-0 grey-text" *ngIf="!plugin.installedVersion">
-        <i class="far fa-fw fa-circle"></i> {{ 'plugins.status_not_installed' | translate }}
+        <i class="far fa-fw fa-circle-xmark"></i> {{ 'plugins.status_not_installed' | translate }}
       </p>
       <p class="mb-0 primary-text" *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable && !plugin.disabled">
         <i class="far fa-fw fa-arrow-alt-circle-up"></i> {{ 'plugins.status_update_available' | translate }}

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -7,7 +7,7 @@
         <i class="far fa-fw fa-circle-check"></i> {{ 'plugins.status_installed' | translate }}
       </p>
       <p class="mb-0 grey-text" *ngIf="!plugin.installedVersion">
-        <i class="far fa-fw fa-circle-arrow-down"></i> {{ 'plugins.status_not_installed' | translate }}
+        <i class="far fa-fw fa-circle-down"></i> {{ 'plugins.status_not_installed' | translate }}
       </p>
       <p class="mb-0 primary-text" *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable && !plugin.disabled">
         <i class="far fa-fw fa-arrow-alt-circle-up"></i> {{ 'plugins.status_update_available' | translate }}


### PR DESCRIPTION
I suggest changing from a regular empty circle to a circle with arrow down. Installed plug-ins have a circle with "check" so it would work well together.

Up the proposal, at the bottom is how it is now:

<img width="712" alt="Zrzut ekranu 2023-11-18 o 00 23 42" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/f19293e4-26c9-4a88-b92c-fd2e2e507b7d">

