### PR TITLE
Dropdown - notification about new update - red dot

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -93,6 +93,7 @@
               <span _ngcontent-ffi-c189="" class="position-absolute p-1 bg-danger rounded-circle ng-star-inserted" 
                 style="left: 10px; top: 20px;"></span>
             </button>
+            <div class="dropdown-divider"></div>
           </ng-container>
           <button ngbDropdownItem *ngIf="plugin.publicPackage" (click)="$plugin.installPreviousVersion(plugin)">
             <i class="fas fa-fw fa-fw fa-history"></i>

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -90,8 +90,9 @@
             <button ngbDropdownItem (click)="$plugin.updatePlugin(plugin, plugin.betaUpdateAvailable ? 'beta' : 'latest')">
               <i class="fas fa-fw fa-arrow-alt-circle-up"></i>
               {{ 'plugins.button_update' | translate }} (v{{ plugin.latestVersion }})
+              <span _ngcontent-ffi-c189="" class="position-absolute p-1 bg-danger rounded-circle ng-star-inserted" 
+                style="left: 10px; top: 20px;"></span>
             </button>
-            <div class="dropdown-divider"></div>
           </ng-container>
           <button ngbDropdownItem *ngIf="plugin.publicPackage" (click)="$plugin.installPreviousVersion(plugin)">
             <i class="fas fa-fw fa-fw fa-history"></i>

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -80,11 +80,11 @@
       <span ngbDropdown placement="bottom-right top-right" class="d-inline-block ml-3">
         <a class="card-link" href="javascript:void(0)" aria-label="Plugin actions drop down menu" ngbDropdownToggle>
           <i class="fas fa-fw fa-ellipsis-v"></i>
-        </a>
-        <span *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable" 
+          <span *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable" 
                 class="position-absolute p-1 bg-danger rounded-circle" 
                 style="right:0px; top:0px;">
         </span>
+        </a>
         <div ngbDropdownMenu aria-labelledby="Plugin actions drop down menu">
           <ng-container *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable">
             <button ngbDropdownItem (click)="$plugin.updatePlugin(plugin, plugin.betaUpdateAvailable ? 'beta' : 'latest')">

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -80,10 +80,8 @@
       <span ngbDropdown placement="bottom-right top-right" class="d-inline-block ml-3">
         <a class="card-link" href="javascript:void(0)" aria-label="Plugin actions drop down menu" ngbDropdownToggle>
           <i class="fas fa-fw fa-ellipsis-v"></i>
-          <span *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable" 
-                class="position-absolute p-1 bg-danger rounded-circle" 
-                style="right:0px; top:0px;">
-        </span>
+          <span *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable" class="position-absolute 
+            p-1 bg-danger rounded-circle" style="right:0px; top:0px;"></span>
         </a>
         <div ngbDropdownMenu aria-labelledby="Plugin actions drop down menu">
           <ng-container *ngIf="plugin.updateAvailable || plugin.betaUpdateAvailable">


### PR DESCRIPTION
It seems to me that since there is a red dot on the dropdown icon, the user after opening dropdown, will be looking for another red dot that will indicate exactly what the notification is about. 

And it looks better in my opinion.

From:
<img width="222" alt="Zrzut ekranu 2023-11-17 o 14 30 30" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/3ad63a87-9cd2-4dbd-9b07-2829201031b5">

To:
<img width="226" alt="Zrzut ekranu 2023-11-17 o 14 50 05" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/ff85925c-7bf2-4a7a-b55c-d85102ef1ee8">


It also includes a small fix for the current red circle next to the dropdown icon - so that it is also clickable and does not block the link.