### PR TITLE
Add Child Bridge Pin Code

### DIFF
--- a/ui/src/app/core/manage-plugins/bridge-plugins-modal/bridge-plugins-modal.component.html
+++ b/ui/src/app/core/manage-plugins/bridge-plugins-modal/bridge-plugins-modal.component.html
@@ -47,7 +47,9 @@
                 <app-qrcode [data]="deviceInfo[item._bridge?.username]._setupCode" class="mr-auto ml-auto mt-2 mb-2"
                   style="width: 180px; height: 180px;">
                 </app-qrcode>
-
+                <p class="mr-auto ml-auto text-center">
+                  {{ deviceInfo[item._bridge?.username].pincode }}
+                </p>
                 <p class="grey-text  mr-auto ml-auto text-center" style="max-width: 400px;">
                   {{ 'status.message_code_scan_instructions' | translate }}
                 </p>


### PR DESCRIPTION
## :recycle: Current situation

Currently when you click into the Child Bridge settings for pairing it doesn't show a PIN code.

## :bulb: Proposed solution

This will now display the PIN code so that you can just type in the code. The reason this is useful is because you can actually set different PIN codes per Child bridge within the plugin's `_bridge` config. Example:
```

            "_bridge": {
                "name": "Homebridge Child Bridge",
                "manufacturer": "Homebridge Child",
                "model": "Bridge",
                "pin": "123-45-678",
                "username": "0A:B1:23:4C:56:7D",
                "port": 54743
            },
```

<img width="792" alt="Screenshot 2023-11-18 at 4 14 13 AM" src="https://github.com/homebridge/homebridge-config-ui-x/assets/9875439/ddd542fe-3a6f-4323-aa27-5f5fe62d989a">
<img width="566" alt="Screenshot 2023-11-18 at 3 59 57 AM" src="https://github.com/homebridge/homebridge-config-ui-x/assets/9875439/3437697f-c6cf-4743-924a-6556753217cb">

## :gear: Release Notes

PIN code is now displayed, under the QR code, when viewing Child Bridge Settings.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
