### PR TITLE
Fix for #1736: fix table width, avoid overflow

### DIFF
--- a/ui/src/app/core/accessories/info-modal/info-modal.component.html
+++ b/ui/src/app/core/accessories/info-modal/info-modal.component.html
@@ -28,7 +28,7 @@
         type="text" id="form-name" autocomplete="off" class="form-control pl-0 pr-0">
       <label for="form-name" class="active" [translate]="'accessories.label_name'">Name</label>
     </div>
-    <table class="table table-borderless table-hover table-striped table-sm">
+    <table class="table table-borderless table-hover table-striped table-sm" style="table-layout:fixed; width:100%;">
       <tbody>
         <tr>
           <th>{{ service.humanType }}</th>


### PR DESCRIPTION
Refer bug #1736 

## :recycle: Current situation
Table width can exceed 100% of modal window
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/df6493c3-c15a-46b0-a183-8ccde3035f05)


## :bulb: Proposed solution
Limit table width to 100%
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/5e5d7db2-1cfa-4ee5-8e21-a38e5e8bcb16)



## :gear: Release Notes
Better display of accessory characteristics should nay have very long values

### Testing
None

### Reviewer Nudging
Please check my changes :)
