### PR TITLE
update lang sync - remove old translations

### DIFF
--- a/scripts/lang-sync.ts
+++ b/scripts/lang-sync.ts
@@ -1,6 +1,7 @@
-
 /**
- * Script to copy new english translation strings to the other language files
+ * Script to:
+ * - copy new english translation strings to the other language files
+ * - remove old translation strings from the other language files
  */
 
 import * as fs from 'fs-extra';
@@ -18,9 +19,17 @@ for (const lang of langFiles) {
   const translationStrings = fs.readJsonSync(langPath);
 
   if (lang !== 'en.json') {
+    // find any keys in the main file that are not in the translation file, and add
     for (const [key, value] of Object.entries(main)) {
       if (!translationStrings.hasOwnProperty(key)) {
         translationStrings[key] = value;
+      }
+    }
+
+    // find any keys in the translation file that are not in the main file, and remove
+    for (const key of Object.keys(translationStrings)) {
+      if (!main.hasOwnProperty(key)) {
+        delete translationStrings[key];
       }
     }
   }


### PR DESCRIPTION
## :recycle: Current situation

the scripts/lang-sync file does not remove entries in other lang files that do not exist in `en.json`

## :bulb: Proposed solution

Apart from adding new entries that exist in `en.json`, also remove entries that do not.

Keeps the other language files up to date so they only contain the used translation strings.

## :gear: Release Notes

changelog updated in a separate PR

### Testing

All existing tests unchanged, no tests added or deleted
