### PR TITLE
Add missing verified label translation fix for #1749

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -33,7 +33,7 @@
         <a href="javascript:void(0)" class="card-link text-decoration-none green-text ml-3" ngbTooltip="@{{ plugin.author }}"
           (click)="openVerifiedModal()">
           <i class="fas fa-fw fa-shield-alt"></i>
-          <span class="d-none d-md-inline"> Verified</span>
+          <span class="d-none d-md-inline"> {{ 'plugins.donate.button_verified' | translate }}</span>
         </a>
       </p>
     </div>

--- a/ui/src/i18n/bg.json
+++ b/ui/src/i18n/bg.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Актуализирай",
     "plugins.button_upgrade": "Актуализирай",
     "plugins.donate.button_donate": "Donate",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Рестартирай Homebridge сега",

--- a/ui/src/i18n/bg.json
+++ b/ui/src/i18n/bg.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Актуализирай",
     "plugins.button_upgrade": "Актуализирай",
     "plugins.donate.button_donate": "Donate",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Проверен",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Рестартирай Homebridge сега",

--- a/ui/src/i18n/ca.json
+++ b/ui/src/i18n/ca.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Actualitzar",
     "plugins.button_upgrade": "Actualitzar",
     "plugins.donate.button_donate": "Donar",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Verificat",
     "plugins.donate.message_learn_more": "Obteniu més informació sobre els enllaços de donació als plugins",
     "plugins.donate.tile_donate_to": "Donar a {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar Homebridge",

--- a/ui/src/i18n/ca.json
+++ b/ui/src/i18n/ca.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Actualitzar",
     "plugins.button_upgrade": "Actualitzar",
     "plugins.donate.button_donate": "Donar",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Obteniu més informació sobre els enllaços de donació als plugins",
     "plugins.donate.tile_donate_to": "Donar a {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar Homebridge",

--- a/ui/src/i18n/cs.json
+++ b/ui/src/i18n/cs.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Aktualizovat",
     "plugins.button_upgrade": "Upgradovat",
     "plugins.donate.button_donate": "Podpořit",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Ověřeno",
     "plugins.donate.message_learn_more": "Zjistěte více o odkazech podpory na pluginech",
     "plugins.donate.tile_donate_to": "Podpořit {{ author }}",
     "plugins.manage.button_restart_now": "Restartujte Homebridge nyní",

--- a/ui/src/i18n/cs.json
+++ b/ui/src/i18n/cs.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Aktualizovat",
     "plugins.button_upgrade": "Upgradovat",
     "plugins.donate.button_donate": "Podpořit",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Zjistěte více o odkazech podpory na pluginech",
     "plugins.donate.tile_donate_to": "Podpořit {{ author }}",
     "plugins.manage.button_restart_now": "Restartujte Homebridge nyní",

--- a/ui/src/i18n/de.json
+++ b/ui/src/i18n/de.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Aktualisieren",
     "plugins.button_upgrade": "Aktualisierung",
     "plugins.donate.button_donate": "Spenden",
+    "plugins.donate.button_verified": "Verifiziert",
     "plugins.donate.message_learn_more": "Erfahre mehr über Spenden-Links bei Plugins",
     "plugins.donate.tile_donate_to": "An {{ author }} spenden",
     "plugins.manage.button_restart_now": "Jetzt neustarten",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Update",
     "plugins.button_upgrade": "Upgrade",
     "plugins.donate.button_donate": "Donate",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Restart Homebridge",

--- a/ui/src/i18n/es.json
+++ b/ui/src/i18n/es.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Actualizar",
     "plugins.button_upgrade": "Actualizar",
     "plugins.donate.button_donate": "Donar",
+    "plugins.donate.button_verified": "Verificado",
     "plugins.donate.message_learn_more": "Aprender más sobre los enlaces de donación de los plugins",
     "plugins.donate.tile_donate_to": "Donar a {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar Homebridge",

--- a/ui/src/i18n/fr.json
+++ b/ui/src/i18n/fr.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Mettre à jour",
     "plugins.button_upgrade": "Mettre à niveau",
     "plugins.donate.button_donate": "Faire un don",
+    "plugins.donate.button_verified": "Vérifié",
     "plugins.donate.message_learn_more": "Informations à propos des dons pour les plugins",
     "plugins.donate.tile_donate_to": "Faire un don à {{ author }}",
     "plugins.manage.button_restart_now": "Redémarrer Homebridge",

--- a/ui/src/i18n/he.json
+++ b/ui/src/i18n/he.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "עדכן",
     "plugins.button_upgrade": "שדרג",
     "plugins.donate.button_donate": "תרום",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "מְאוּמָת",
     "plugins.donate.message_learn_more": "למה יותר על לינקי תרומה לתוספים",
     "plugins.donate.tile_donate_to": "תרום ל {{ author }}",
     "plugins.manage.button_restart_now": "אתחל הומברידג' עכשיו",

--- a/ui/src/i18n/he.json
+++ b/ui/src/i18n/he.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "עדכן",
     "plugins.button_upgrade": "שדרג",
     "plugins.donate.button_donate": "תרום",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "למה יותר על לינקי תרומה לתוספים",
     "plugins.donate.tile_donate_to": "תרום ל {{ author }}",
     "plugins.manage.button_restart_now": "אתחל הומברידג' עכשיו",

--- a/ui/src/i18n/hu.json
+++ b/ui/src/i18n/hu.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Frissítés (update)",
     "plugins.button_upgrade": "Frissítés (upgrade)",
     "plugins.donate.button_donate": "Donate",
+    "plugins.donate.button_verified": "Ellenőrzött",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Homebridge újraindítása most",

--- a/ui/src/i18n/id.json
+++ b/ui/src/i18n/id.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Pembaruan",
     "plugins.button_upgrade": "Peningkatan",
     "plugins.donate.button_donate": "Donasi",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Pelajari lebih lanjut tentang link donasi plugin",
     "plugins.donate.tile_donate_to": "Donasi ke {{ author }}",
     "plugins.manage.button_restart_now": "Mengulang Kembali Homebridge Sekarang",

--- a/ui/src/i18n/id.json
+++ b/ui/src/i18n/id.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Pembaruan",
     "plugins.button_upgrade": "Peningkatan",
     "plugins.donate.button_donate": "Donasi",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Diverifikasi",
     "plugins.donate.message_learn_more": "Pelajari lebih lanjut tentang link donasi plugin",
     "plugins.donate.tile_donate_to": "Donasi ke {{ author }}",
     "plugins.manage.button_restart_now": "Mengulang Kembali Homebridge Sekarang",

--- a/ui/src/i18n/it.json
+++ b/ui/src/i18n/it.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Aggiorna",
     "plugins.button_upgrade": "Aggiorna sistema",
     "plugins.donate.button_donate": "Dona",
+    "plugins.donate.button_verified": "Verificato",
     "plugins.donate.message_learn_more": "Scopri di più riguardo i link per le donazioni dei plugin",
     "plugins.donate.tile_donate_to": "Dona a {{ author }}",
     "plugins.manage.button_restart_now": "Riavvia Homebridge adesso",

--- a/ui/src/i18n/ja.json
+++ b/ui/src/i18n/ja.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "更新",
     "plugins.donate.button_donate": "寄付する",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "プラグインの寄付リンクについてさらに詳しく",
     "plugins.donate.tile_donate_to": "{{ author }} に寄付する",
     "plugins.manage.button_restart_now": "いますぐHomebridgeを再起動",

--- a/ui/src/i18n/ja.json
+++ b/ui/src/i18n/ja.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "更新",
     "plugins.donate.button_donate": "寄付する",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "確認済み",
     "plugins.donate.message_learn_more": "プラグインの寄付リンクについてさらに詳しく",
     "plugins.donate.tile_donate_to": "{{ author }} に寄付する",
     "plugins.manage.button_restart_now": "いますぐHomebridgeを再起動",

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "업데이트",
     "plugins.button_upgrade": "업그레이드",
     "plugins.donate.button_donate": "기부",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "플러그인의 기부 링크에 대해 자세히 알아보기",
     "plugins.donate.tile_donate_to": "{{ author }}에 기부",
     "plugins.manage.button_restart_now": "지금 Homebridge 재시작",

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "업데이트",
     "plugins.button_upgrade": "업그레이드",
     "plugins.donate.button_donate": "기부",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "확인됨",
     "plugins.donate.message_learn_more": "플러그인의 기부 링크에 대해 자세히 알아보기",
     "plugins.donate.tile_donate_to": "{{ author }}에 기부",
     "plugins.manage.button_restart_now": "지금 Homebridge 재시작",

--- a/ui/src/i18n/mk.json
+++ b/ui/src/i18n/mk.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Ажурирај",
     "plugins.button_upgrade": "Надгради",
     "plugins.donate.button_donate": "Донирај",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Потврдено",
     "plugins.donate.message_learn_more": "Дознај повеќе за донациски линкови",
     "plugins.donate.tile_donate_to": "Донирај на {{ author }}",
     "plugins.manage.button_restart_now": "Рестартирај Homebridge",

--- a/ui/src/i18n/mk.json
+++ b/ui/src/i18n/mk.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Ажурирај",
     "plugins.button_upgrade": "Надгради",
     "plugins.donate.button_donate": "Донирај",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Дознај повеќе за донациски линкови",
     "plugins.donate.tile_donate_to": "Донирај на {{ author }}",
     "plugins.manage.button_restart_now": "Рестартирај Homebridge",

--- a/ui/src/i18n/nl.json
+++ b/ui/src/i18n/nl.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Update",
     "plugins.button_upgrade": "Upgrade",
     "plugins.donate.button_donate": "Doneer",
+    "plugins.donate.button_verified": "Geverifieerd",
     "plugins.donate.message_learn_more": "Meer informatie over donatie links van plugins",
     "plugins.donate.tile_donate_to": "Doneer aan {{ author }}",
     "plugins.manage.button_restart_now": "Herstart Homebridge Nu",

--- a/ui/src/i18n/no.json
+++ b/ui/src/i18n/no.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Oppdatering",
     "plugins.button_upgrade": "oppgradering",
     "plugins.donate.button_donate": "Donate",
+    "plugins.donate.button_verified": "Verifisert",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Starte Homebridge på nytt nå",

--- a/ui/src/i18n/pl.json
+++ b/ui/src/i18n/pl.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Aktualizuj (update)",
     "plugins.button_upgrade": "Aktualizuj (upgrade)",
     "plugins.donate.button_donate": "Wspomóż",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Zweryfikowano",
     "plugins.donate.message_learn_more": "Przeczytaj więcej o stosowaniu linków wspomagania we wtyczkach",
     "plugins.donate.tile_donate_to": "Wspomóż {{ author }}",
     "plugins.manage.button_restart_now": "Uruchom ponownie teraz",

--- a/ui/src/i18n/pl.json
+++ b/ui/src/i18n/pl.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Aktualizuj (update)",
     "plugins.button_upgrade": "Aktualizuj (upgrade)",
     "plugins.donate.button_donate": "Wspomóż",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Przeczytaj więcej o stosowaniu linków wspomagania we wtyczkach",
     "plugins.donate.tile_donate_to": "Wspomóż {{ author }}",
     "plugins.manage.button_restart_now": "Uruchom ponownie teraz",

--- a/ui/src/i18n/pt-BR.json
+++ b/ui/src/i18n/pt-BR.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Atualizar",
     "plugins.button_upgrade": "Atualizar",
     "plugins.donate.button_donate": "Doar",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Verificado",
     "plugins.donate.message_learn_more": "Saber mais sobre links de doações em plugins",
     "plugins.donate.tile_donate_to": "Doar para {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar Homebridge",

--- a/ui/src/i18n/pt-BR.json
+++ b/ui/src/i18n/pt-BR.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Atualizar",
     "plugins.button_upgrade": "Atualizar",
     "plugins.donate.button_donate": "Doar",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Saber mais sobre links de doações em plugins",
     "plugins.donate.tile_donate_to": "Doar para {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar Homebridge",

--- a/ui/src/i18n/pt.json
+++ b/ui/src/i18n/pt.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Atualizar",
     "plugins.button_upgrade": "Atualizar Versão",
     "plugins.donate.button_donate": "Doar",
+    "plugins.donate.button_verified": "Verificado",
     "plugins.donate.message_learn_more": "Veja mais acerca dos links de doação nos plugins",
     "plugins.donate.tile_donate_to": "Doar a {{ author }}",
     "plugins.manage.button_restart_now": "Reiniciar o Homebridge",

--- a/ui/src/i18n/ru.json
+++ b/ui/src/i18n/ru.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Обновить",
     "plugins.button_upgrade": "Обновить",
     "plugins.donate.button_donate": "Donate",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Проверено",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Перезапустить Homebridge прямо сейчас",

--- a/ui/src/i18n/ru.json
+++ b/ui/src/i18n/ru.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Обновить",
     "plugins.button_upgrade": "Обновить",
     "plugins.donate.button_donate": "Donate",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Learn more about donation links on plugins",
     "plugins.donate.tile_donate_to": "Donate to {{ author }}",
     "plugins.manage.button_restart_now": "Перезапустить Homebridge прямо сейчас",

--- a/ui/src/i18n/sl.json
+++ b/ui/src/i18n/sl.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Nadgradnja",
     "plugins.button_upgrade": "Nadgradnja",
     "plugins.donate.button_donate": "Doniraj",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Preverjeno",
     "plugins.donate.message_learn_more": "Preberite več o povezavah za donacije vtičnikov",
     "plugins.donate.tile_donate_to": "Doniraj {{ author }}",
     "plugins.manage.button_restart_now": "Znova zaženite Homebridge",

--- a/ui/src/i18n/sl.json
+++ b/ui/src/i18n/sl.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Nadgradnja",
     "plugins.button_upgrade": "Nadgradnja",
     "plugins.donate.button_donate": "Doniraj",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Preberite več o povezavah za donacije vtičnikov",
     "plugins.donate.tile_donate_to": "Doniraj {{ author }}",
     "plugins.manage.button_restart_now": "Znova zaženite Homebridge",

--- a/ui/src/i18n/sv.json
+++ b/ui/src/i18n/sv.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Uppdatering",
     "plugins.button_upgrade": "Uppgradering",
     "plugins.donate.button_donate": "Donera",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Läs mer om donationslänkar i plugins",
     "plugins.donate.tile_donate_to": "Donera till {{ author }}",
     "plugins.manage.button_restart_now": "Starta om Homebridge nu",

--- a/ui/src/i18n/sv.json
+++ b/ui/src/i18n/sv.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Uppdatering",
     "plugins.button_upgrade": "Uppgradering",
     "plugins.donate.button_donate": "Donera",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Verifierad",
     "plugins.donate.message_learn_more": "Läs mer om donationslänkar i plugins",
     "plugins.donate.tile_donate_to": "Donera till {{ author }}",
     "plugins.manage.button_restart_now": "Starta om Homebridge nu",

--- a/ui/src/i18n/th.json
+++ b/ui/src/i18n/th.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "อัปเดท",
     "plugins.button_upgrade": "อัพเกรด",
     "plugins.donate.button_donate": "บริจาค",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "เรียนรู้เพิ่มเติมเกี่ยวกับลิงก์การบริจาคในปลั๊กอิน",
     "plugins.donate.tile_donate_to": "บริจาคให้ {{ author }}",
     "plugins.manage.button_restart_now": "รีสตาร์ท Homebridge ทันที",

--- a/ui/src/i18n/th.json
+++ b/ui/src/i18n/th.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "อัปเดท",
     "plugins.button_upgrade": "อัพเกรด",
     "plugins.donate.button_donate": "บริจาค",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "ตรวจสอบแล้ว",
     "plugins.donate.message_learn_more": "เรียนรู้เพิ่มเติมเกี่ยวกับลิงก์การบริจาคในปลั๊กอิน",
     "plugins.donate.tile_donate_to": "บริจาคให้ {{ author }}",
     "plugins.manage.button_restart_now": "รีสตาร์ท Homebridge ทันที",

--- a/ui/src/i18n/tr.json
+++ b/ui/src/i18n/tr.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Güncelle",
     "plugins.button_upgrade": "Yükselt",
     "plugins.donate.button_donate": "Bağış Yap",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Doğrulandı",
     "plugins.donate.message_learn_more": "Eklentilerdeki bağış bağlantıları hakkkında daha fazla bilgi edinin",
     "plugins.donate.tile_donate_to": "{{ author }} Kişisine Bağış Yap.",
     "plugins.manage.button_restart_now": "Homebridge'i Şimdi Yeniden Başlat",

--- a/ui/src/i18n/tr.json
+++ b/ui/src/i18n/tr.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Güncelle",
     "plugins.button_upgrade": "Yükselt",
     "plugins.donate.button_donate": "Bağış Yap",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Eklentilerdeki bağış bağlantıları hakkkında daha fazla bilgi edinin",
     "plugins.donate.tile_donate_to": "{{ author }} Kişisine Bağış Yap.",
     "plugins.manage.button_restart_now": "Homebridge'i Şimdi Yeniden Başlat",

--- a/ui/src/i18n/uk.json
+++ b/ui/src/i18n/uk.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "Оновити",
     "plugins.button_upgrade": "Обновить",
     "plugins.donate.button_donate": "Пожертвувати",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "Перевірено",
     "plugins.donate.message_learn_more": "Дізнайтесь більше про посилання на пожертви у плагінах",
     "plugins.donate.tile_donate_to": "Пожертувати для {{ author }}",
     "plugins.manage.button_restart_now": "Перезапустити Homebridge негайно",

--- a/ui/src/i18n/uk.json
+++ b/ui/src/i18n/uk.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "Оновити",
     "plugins.button_upgrade": "Обновить",
     "plugins.donate.button_donate": "Пожертвувати",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "Дізнайтесь більше про посилання на пожертви у плагінах",
     "plugins.donate.tile_donate_to": "Пожертувати для {{ author }}",
     "plugins.manage.button_restart_now": "Перезапустити Homebridge негайно",

--- a/ui/src/i18n/zh-CN.json
+++ b/ui/src/i18n/zh-CN.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "升级",
     "plugins.donate.button_donate": "打赏",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "了解更多关于插件页面的打赏链接",
     "plugins.donate.tile_donate_to": "打赏给 {{ author }}",
     "plugins.manage.button_restart_now": "立即重启 Homebridge",

--- a/ui/src/i18n/zh-CN.json
+++ b/ui/src/i18n/zh-CN.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "升级",
     "plugins.donate.button_donate": "打赏",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "已验证",
     "plugins.donate.message_learn_more": "了解更多关于插件页面的打赏链接",
     "plugins.donate.tile_donate_to": "打赏给 {{ author }}",
     "plugins.manage.button_restart_now": "立即重启 Homebridge",

--- a/ui/src/i18n/zh-TW.json
+++ b/ui/src/i18n/zh-TW.json
@@ -179,7 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "升級",
     "plugins.donate.button_donate": "贊助",
-    "plugins.donate.button_verified": "Verified",
+    "plugins.donate.button_verified": "已验证",
     "plugins.donate.message_learn_more": "了解更多 Plugin 的贊助連結",
     "plugins.donate.tile_donate_to": "贊助 {{ author }}",
     "plugins.manage.button_restart_now": "立即重新啟動 Homebridge",

--- a/ui/src/i18n/zh-TW.json
+++ b/ui/src/i18n/zh-TW.json
@@ -179,6 +179,7 @@
     "plugins.button_update": "更新",
     "plugins.button_upgrade": "升級",
     "plugins.donate.button_donate": "贊助",
+    "plugins.donate.button_verified": "Verified",
     "plugins.donate.message_learn_more": "了解更多 Plugin 的贊助連結",
     "plugins.donate.tile_donate_to": "贊助 {{ author }}",
     "plugins.manage.button_restart_now": "立即重新啟動 Homebridge",


### PR DESCRIPTION
## :recycle: Current situation
No translation exists for the label Verified, see bug #1749

## :bulb: Proposed solution
Added translation code and also all translations for all languages. Fixes #1749

## :gear: Release Notes
Added translation for the plugin Verified button

## :heavy_plus_sign: Additional Information
I also provided translations for all supported languages

### Testing
None yet

### Reviewer Nudging
Please review the changes