### PR TITLE
Sidebar and animation to hamburger menu

### DIFF
--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -167,7 +167,7 @@
             <i class='fa fa-cog' ></i>
             <span class="link_name">Settings</span>
           </a>
-          <i class='fa fa-chevron-down arrow' data-bs-toggle="collapse"  data-bs-target=".li-link1" ></i>
+          <i class='fa fa-chevron-down arrow' data-toggle="collapse"  data-target=".li-link1" ></i>
         </div>
         <ul class="sub-menu">
           <li><a class="link_name" href="#">Homebridge settings</a></li>
@@ -186,7 +186,7 @@
             <i class='fa fa-power-off' ></i>
             <span class="link_name">Restart</span>
           </a>
-          <i class='fa fa-chevron-down arrow' data-bs-toggle="collapse"  data-bs-target=".li-link2"></i>
+          <i class='fa fa-chevron-down arrow' data-toggle="collapse"  data-target=".li-link2"></i>
         </div>
         <ul class="sub-menu">
           <li><a class="link_name" href="#">Restart Homebridge</a></li>
@@ -209,7 +209,7 @@
 
       <li>
         <div class="iocn-link" style="position: fixed; bottom:0;">
-          <a href="#" data-bs-toggle="collapse"  data-bs-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
+          <a href="#" data-toggle="collapse"  data-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
             <i id="chevron" class='fa fa-chevron-right' ></i>
           </a>        
         </div>

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -1,6 +1,5 @@
 <!--Main Navigation-->
 <header *ngIf="$settings.theme && $auth.user">
-
   <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-primary scrolling-navbar d-lg-none">
     <a class="navbar-brand" routerLink="/">
       <img class="menu-logo" src="/assets/homebridge-logo.svg" />
@@ -28,7 +27,6 @@
           <a class="nav-link" routerLink="/accessories" [translate]="'menu.label_accessories'">Accessories</a>
         </li>
       </ul>
-
       <ul class="navbar-nav nav-flex-icons hb-nav-right">
         <li class="nav-item mr-3" *ngIf="rPiWasUnderVoltage || rPiCurrentlyUnderVoltage">
           <a href="javascript:void(0)" class="nav-link dropdown-toggle waves-effect waves-light"
@@ -40,7 +38,6 @@
               [ngClass]="{ 'fa-beat': rPiCurrentlyUnderVoltage }"></i>
           </a>
         </li>
-
         <li class="nav-item waves-effect waves-light" routerLinkActive="active" placement="bottom"
           ngbTooltip="{{'menu.tooltip_view_logs' | translate}}" container="body">
           <a class="nav-link" routerLink="/logs" aria-label="View Homebridge Logs">
@@ -53,7 +50,6 @@
             <i #restartHomebridgeIcon class="fas fa-fw fa-power-off nav-menu-icon"></i>
           </a>
         </li>
-
         <li class="nav-item dropdown">
           <a href="javascript:void(0)" class="nav-link dropdown-toggle waves-effect waves-light" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="false" aria-label="more actions dropdown menu">
@@ -91,25 +87,17 @@
             </a>
           </div>
         </li>
-
       </ul>
     </div>
   </nav>
-
 </header>
-
 <div class="container-fluid d-flex flex-col h-100 w-100 p-0">
-
    <div class="sidebar show d-none d-lg-block p-0">
     <div class="logo-details">
       <img style="height:30px;" src="assets/homebridge-logo.svg" alt="logo">
       <span class="logo_name">Homebridge</span>
     </div>
-
-
-
     <ul class="nav-links">
-      
       <li>
         <a href="#">
           <i class='fa fa-house'></i>
@@ -119,7 +107,6 @@
           <li><a class="link_name" href="#">Dashboard</a></li>
         </ul>
       </li>
-
       <li>
         <a href="#">
           <i class='fa fa-plug'></i>
@@ -129,7 +116,6 @@
           <li><a class="link_name" href="#">Plugins</a></li>
         </ul>
       </li>
-
       <li>
         <a href="#">
           <i class='fa fa-lightbulb'></i>
@@ -139,7 +125,6 @@
           <li><a class="link_name" href="#">Accessories</a></li>
         </ul>
       </li>
-
       <li>
         <a href="#">
           <i class='fa fa-timeline'></i>
@@ -149,7 +134,6 @@
           <li><a class="link_name" href="#">Logs</a></li>
         </ul>
       </li>
-
       <li>
         <a href="#">
           <i class='fa fa-terminal'></i>
@@ -159,8 +143,6 @@
           <li><a class="link_name" href="#">Terminal</a></li>
         </ul>
       </li>
-
-
       <li class="li-link1">
         <div class="iocn-link">
           <a href="#">
@@ -176,10 +158,8 @@
           <li><a href="#">Backup</a></li>
           <li><a href="#">Config</a></li>
           <li><a href="#">Users</a></li>
-          
         </ul>
       </li>
-
       <li class="li-link2">
         <div class="iocn-link">
           <a href="#">
@@ -194,7 +174,6 @@
           <li><a href="#">Shutdown server</a></li>
         </ul>
       </li>
-
       <li>
         <div class="iocn-link">
           <a href="#">
@@ -206,7 +185,6 @@
           <li><a class="link_name" href="#">Logout - admin</a></li>
         </ul>
       </li>
-
       <li>
         <div class="iocn-link" style="position: fixed; bottom:0;">
           <a href="#" data-toggle="collapse"  data-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
@@ -214,11 +192,8 @@
           </a>        
         </div>
       </li>
-
     </ul>
   </div>
-
-  
   <div class="w-100 p-3">
     <router-outlet></router-outlet>
   </div>

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -1,7 +1,7 @@
 <!--Main Navigation-->
 <header *ngIf="$settings.theme && $auth.user">
 
-  <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-primary scrolling-navbar">
+  <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-primary scrolling-navbar d-lg-none">
     <a class="navbar-brand" routerLink="/">
       <img class="menu-logo" src="/assets/homebridge-logo.svg" />
       <strong>Homebridge</strong>

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -199,7 +199,7 @@
         <div class="iocn-link">
           <a href="#">
             <i class='fa fa-right-from-bracket' ></i>
-            <span class="link_name">Logout<br><span class="text-mutted">admin</span></span>
+            <span class="link_name">Logout<br><span class="text-muted">admin</span></span>
           </a>       
         </div>
         <ul class="sub-menu blank">

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -100,7 +100,7 @@
     <ul class="nav-links">
       <li>
         <a href="#">
-          <i class='fa fa-house'></i>
+          <i class="fa fa-house"></i>
           <span class="link_name">Dashboard</span>
         </a>
         <ul class="sub-menu blank">
@@ -109,7 +109,7 @@
       </li>
       <li>
         <a href="#">
-          <i class='fa fa-plug'></i>
+          <i class="fa fa-plug"></i>
           <span class="link_name">Plugins</span>
         </a>
         <ul class="sub-menu blank">
@@ -118,7 +118,7 @@
       </li>
       <li>
         <a href="#">
-          <i class='fa fa-lightbulb'></i>
+          <i class="fa fa-lightbulb"></i>
           <span class="link_name">Accessories</span>
         </a>
         <ul class="sub-menu blank">
@@ -127,7 +127,7 @@
       </li>
       <li>
         <a href="#">
-          <i class='fa fa-timeline'></i>
+          <i class="fa fa-timeline"></i>
           <span class="link_name">Logs</span>
         </a>
         <ul class="sub-menu blank">
@@ -136,7 +136,7 @@
       </li>
       <li>
         <a href="#">
-          <i class='fa fa-terminal'></i>
+          <i class="fa fa-terminal"></i>
           <span class="link_name">Terminal</span>
         </a>
         <ul class="sub-menu blank">
@@ -146,10 +146,10 @@
       <li class="li-link1">
         <div class="iocn-link">
           <a href="#">
-            <i class='fa fa-cog' ></i>
+            <i class="fa fa-cog"></i>
             <span class="link_name">Settings</span>
           </a>
-          <i class='fa fa-chevron-down arrow' data-toggle="collapse"  data-target=".li-link1" ></i>
+          <i class="fa fa-chevron-down arrow" data-toggle="collapse"  data-target=".li-link1"></i>
         </div>
         <ul class="sub-menu">
           <li><a class="link_name" href="#">Homebridge settings</a></li>
@@ -163,10 +163,10 @@
       <li class="li-link2">
         <div class="iocn-link">
           <a href="#">
-            <i class='fa fa-power-off' ></i>
+            <i class="fa fa-power-off"></i>
             <span class="link_name">Restart</span>
           </a>
-          <i class='fa fa-chevron-down arrow' data-toggle="collapse"  data-target=".li-link2"></i>
+          <i class="fa fa-chevron-down arrow" data-toggle="collapse"  data-target=".li-link2"></i>
         </div>
         <ul class="sub-menu">
           <li><a class="link_name" href="#">Restart Homebridge</a></li>
@@ -177,7 +177,7 @@
       <li>
         <div class="iocn-link">
           <a href="#">
-            <i class='fa fa-right-from-bracket' ></i>
+            <i class="fa fa-right-from-bracket"></i>
             <span class="link_name">Logout<br><span class="text-muted">admin</span></span>
           </a>       
         </div>
@@ -187,8 +187,8 @@
       </li>
       <li>
         <div class="iocn-link" style="position: fixed; bottom:0;">
-          <a href="#" data-toggle="collapse"  data-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
-            <i id="chevron" class='fa fa-chevron-right' ></i>
+          <a href="#" data-toggle="collapse" data-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
+            <i id="chevron" class="fa fa-chevron-right"></i>
           </a>        
         </div>
       </li>

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -98,8 +98,128 @@
 
 </header>
 
-<div class="container-fluid d-flex flex-col h-100 w-100">
-  <div class="w-100">
+<div class="container-fluid d-flex flex-col h-100 w-100 p-0">
+
+   <div class="sidebar show d-none d-lg-block p-0">
+    <div class="logo-details">
+      <img style="height:30px;" src="assets/homebridge-logo.svg" alt="logo">
+      <span class="logo_name">Homebridge</span>
+    </div>
+
+
+
+    <ul class="nav-links">
+      
+      <li>
+        <a href="#">
+          <i class='fa fa-house'></i>
+          <span class="link_name">Dashboard</span>
+        </a>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Dashboard</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">
+          <i class='fa fa-plug'></i>
+          <span class="link_name">Plugins</span>
+        </a>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Plugins</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">
+          <i class='fa fa-lightbulb'></i>
+          <span class="link_name">Accessories</span>
+        </a>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Accessories</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">
+          <i class='fa fa-timeline'></i>
+          <span class="link_name">Logs</span>
+        </a>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Logs</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <a href="#">
+          <i class='fa fa-terminal'></i>
+          <span class="link_name">Terminal</span>
+        </a>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Terminal</a></li>
+        </ul>
+      </li>
+
+
+      <li class="li-link1">
+        <div class="iocn-link">
+          <a href="#">
+            <i class='fa fa-cog' ></i>
+            <span class="link_name">Settings</span>
+          </a>
+          <i class='fa fa-chevron-down arrow' data-bs-toggle="collapse"  data-bs-target=".li-link1" ></i>
+        </div>
+        <ul class="sub-menu">
+          <li><a class="link_name" href="#">Homebridge settings</a></li>
+          <li><a href="#">Homebridge settings</a></li>
+          <li><a href="#">UI Settings</a></li>
+          <li><a href="#">Backup</a></li>
+          <li><a href="#">Config</a></li>
+          <li><a href="#">Users</a></li>
+          
+        </ul>
+      </li>
+
+      <li class="li-link2">
+        <div class="iocn-link">
+          <a href="#">
+            <i class='fa fa-power-off' ></i>
+            <span class="link_name">Restart</span>
+          </a>
+          <i class='fa fa-chevron-down arrow' data-bs-toggle="collapse"  data-bs-target=".li-link2"></i>
+        </div>
+        <ul class="sub-menu">
+          <li><a class="link_name" href="#">Restart Homebridge</a></li>
+          <li><a href="#">Restart server</a></li>
+          <li><a href="#">Shutdown server</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <div class="iocn-link">
+          <a href="#">
+            <i class='fa fa-right-from-bracket' ></i>
+            <span class="link_name">Logout<br><span class="text-secondary">admin</span></span>
+          </a>       
+        </div>
+        <ul class="sub-menu blank">
+          <li><a class="link_name" href="#">Logout - admin</a></li>
+        </ul>
+      </li>
+
+      <li>
+        <div class="iocn-link" style="position: fixed; bottom:0;">
+          <a href="#" data-bs-toggle="collapse"  data-bs-target=".sidebar,#chevron" aria-expanded="false" aria-controls=".sidebar">
+            <i id="chevron" class='fa fa-chevron-right' ></i>
+          </a>        
+        </div>
+      </li>
+
+    </ul>
+  </div>
+
+  
+  <div class="w-100 p-3">
     <router-outlet></router-outlet>
   </div>
 </div>

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -199,7 +199,7 @@
         <div class="iocn-link">
           <a href="#">
             <i class='fa fa-right-from-bracket' ></i>
-            <span class="link_name">Logout<br><span class="text-secondary">admin</span></span>
+            <span class="link_name">Logout<br><span class="text-mutted">admin</span></span>
           </a>       
         </div>
         <ul class="sub-menu blank">

--- a/ui/src/app/shared/layout/layout.component.html
+++ b/ui/src/app/shared/layout/layout.component.html
@@ -6,9 +6,11 @@
       <img class="menu-logo" src="/assets/homebridge-logo.svg" />
       <strong>Homebridge</strong>
     </a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+    <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
       aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
+      <span class="toggler-icon top-bar"></span>
+      <span class="toggler-icon middle-bar"></span>
+      <span class="toggler-icon bottom-bar"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav mr-auto">

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -84,7 +84,7 @@
 /* SIDEBAR NAVBAR */
 
 .sidebar {
-  position: fixed;
+  position: relative;
   top: 0;
   left: 0;
   height: 100%;

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -3,10 +3,6 @@
     padding-top: 0px !important;
 }
 
-
-
-
-
 /* MOBILE NAVBAR */
 
 .navbar-toggler {
@@ -48,7 +44,6 @@
     margin-top: 0px;
 }
 
-
 /* State when the navbar is collapsed */
 
 .navbar-toggler.collapsed .top-bar {
@@ -87,7 +82,6 @@
   top: inherit;
   transform: rotate(-135deg);
 }
-
 
 /* SIDEBAR NAVBAR */
 
@@ -210,9 +204,11 @@
   opacity: 0.6;
   transition: all 0.3s ease;
 }
+  
 .sidebar .nav-links li .sub-menu a:hover{
   opacity: 1;
 }
+  
 .sidebar.show .nav-links li .sub-menu{
   position: absolute;
   left: 100%;
@@ -225,20 +221,24 @@
   pointer-events: none;
   transition: 0s;
 }
+  
 .sidebar.show .nav-links li:hover .sub-menu{
   top: 0;
   opacity: 1;
   pointer-events: auto;
   transition: all 0.4s ease;
 }
+  
 .sidebar .nav-links li .sub-menu .link_name{
   display: none;
 }
+  
 .sidebar.show .nav-links li .sub-menu .link_name{
   font-size: 18px;
   opacity: 1;
   display: block;
 }
+  
 .sidebar .nav-links li .sub-menu.blank{
   opacity: 1;
   pointer-events: auto;
@@ -246,6 +246,7 @@
   opacity: 0;
   pointer-events: none;
 }
+  
 .sidebar .nav-links li:hover .sub-menu.blank{
   top: 50%;
   transform: translateY(-50%);
@@ -254,7 +255,7 @@
 .li-link1.show, .li-link2.show {
   background: #333333;
   transition: 0s;
-  }
+}
 
 .li-link1, .li-link2 {
   display: block !important;
@@ -263,6 +264,7 @@
 #chevron {
   display: inline;
 }
+  
 #chevron.show {
   transform: rotate(-180deg);
 }
@@ -273,13 +275,7 @@
   display: none;
 }
 
-
-
-
-
-
-
-
+/* ELSE */
 
 .menu-logo {
   margin-right: 10px;

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -1,6 +1,7 @@
 @media (max-width: 991px) {
   .body-top-padding {
     padding-top: 0px !important;
+  }
 }
 
 /* MOBILE NAVBAR */

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -1,3 +1,278 @@
+
+/* MOBILE NAVBAR */
+
+.navbar-toggler {
+    width: 20px;
+    height: 20px;
+    position: relative;
+    transition: .5s ease-in-out;
+}
+
+.navbar-toggler,
+.navbar-toggler:focus,
+.navbar-toggler:active,
+.navbar-toggler-icon:focus {
+    outline: none;
+    box-shadow: none;
+    border: 0 !important;
+    position: relative;
+}
+
+.navbar-toggler span {
+    margin: 0;
+    padding: 0;
+}
+
+.toggler-icon {
+    display: block;
+    position: absolute;
+    height: 3px;
+    width: 100%;
+    background: #ffffff;
+    border-radius: 1px;
+    opacity: 1;
+    left: 0;
+    transform: rotate(0deg);
+    transition: .25s ease-in-out;
+}
+
+.middle-bar {
+    margin-top: 0px;
+}
+
+
+/* State when the navbar is collapsed */
+
+.navbar-toggler.collapsed .top-bar {
+  position: absolute !important;
+  top: 0px !important;
+  transform: rotate(0deg) !important
+}
+
+.navbar-toggler.collapsed .middle-bar {
+  opacity: 1;
+  position: absolute;
+  top: 10px;
+  filter: alpha(opacity=0);
+}
+
+.navbar-toggler.collapsed .bottom-bar {
+  position: absolute;
+  top: 20px;
+  transform: rotate(0deg);
+}
+
+/* when navigation is clicked */
+
+.navbar-toggler:not(.collapsed) .top-bar {
+  top: inherit;
+  transform: rotate(135deg);
+}
+
+.navbar-toggler:not(.collapsed) .middle-bar {
+  opacity: 0;
+  top: inherit;
+  filter: alpha(opacity=0);
+}
+
+.navbar-toggler:not(.collapsed) .bottom-bar {
+  top: inherit;
+  transform: rotate(-135deg);
+}
+
+
+/* SIDEBAR NAVBAR */
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 260px;
+  background: #0f0f0f;
+  z-index: 100;
+  transition: all 0.5s ease;
+}
+.sidebar.show{
+  width: 78px;
+  height: 100%;
+}
+.sidebar.collapsing {
+  height: 100% !important;
+}
+.sidebar .logo-details{
+  height: 60px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+.sidebar .logo-details i, .sidebar .logo-details img {
+  font-size: 30px;
+  color: #fff;
+  height: 50px;
+  min-width: 78px;
+  text-align: center;
+  line-height: 50px;
+}
+.sidebar .logo-details .logo_name{
+  font-size: 22px;
+  color: #fff;
+  font-weight: 600;
+  transition: 0.3s ease;
+  transition-delay: 0.1s;
+}
+.sidebar.show .logo-details .logo_name{
+  transition-delay: 0s;
+  opacity: 0;
+  pointer-events: none;
+}
+.sidebar .nav-links{
+  height: 100%;
+  padding: 30px 0 150px 0;
+  overflow: auto;
+}
+.sidebar.show .nav-links{
+  overflow: visible;
+}
+.sidebar .nav-links::-webkit-scrollbar{
+  display: none;
+}
+.sidebar .nav-links li{
+  position: relative;
+  list-style: none;
+  transition: all 0.4s ease;
+}
+.sidebar .nav-links li:hover{
+  background: #333333;
+}
+.sidebar .nav-links li .iocn-link{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.sidebar.show .nav-links li .iocn-link{
+  display: block;
+}
+.sidebar .nav-links li i{
+  height: 50px;
+  min-width: 78px;
+  text-align: center;
+  line-height: 50px;
+  color: #fff;
+  font-size: 20px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.sidebar .nav-links li.show i.arrow {
+  transform: rotate(-180deg);
+}
+.sidebar.show .nav-links i.arrow{
+  display: none;
+}
+.sidebar .nav-links li a{
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+.sidebar .nav-links li a .link_name{
+  font-size: 18px;
+  font-weight: 400;
+  color: #fff;
+  transition: all 0.4s ease;
+}
+.sidebar.show .nav-links li a .link_name{
+  opacity: 0;
+  pointer-events: none;
+}
+.sidebar .nav-links li .sub-menu{
+  padding: 6px 6px 14px 80px;
+  margin-top: -10px;
+  background: #333333;
+  display: none;
+  transition: all 0.3s ease;
+}
+.sidebar .nav-links li.show .sub-menu{
+  display: block;
+}
+.sidebar .nav-links li .sub-menu a{
+  color: #fff;
+  font-size: 15px;
+  padding: 5px 0;
+  white-space: nowrap;
+  opacity: 0.6;
+  transition: all 0.3s ease;
+}
+.sidebar .nav-links li .sub-menu a:hover{
+  opacity: 1;
+}
+.sidebar.show .nav-links li .sub-menu{
+  position: absolute;
+  left: 100%;
+  top: -10px;
+  margin-top: 0;
+  padding: 10px 20px;
+  border-radius: 0 6px 6px 0;
+  opacity: 0;
+  display: block;
+  pointer-events: none;
+  transition: 0s;
+}
+.sidebar.show .nav-links li:hover .sub-menu{
+  top: 0;
+  opacity: 1;
+  pointer-events: auto;
+  transition: all 0.4s ease;
+}
+.sidebar .nav-links li .sub-menu .link_name{
+  display: none;
+}
+.sidebar.show .nav-links li .sub-menu .link_name{
+  font-size: 18px;
+  opacity: 1;
+  display: block;
+}
+.sidebar .nav-links li .sub-menu.blank{
+  opacity: 1;
+  pointer-events: auto;
+  padding: 3px 20px 6px 16px;
+  opacity: 0;
+  pointer-events: none;
+}
+.sidebar .nav-links li:hover .sub-menu.blank{
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.li-link1.show, .li-link2.show {
+  background: #333333;
+  transition: 0s;
+  }
+
+.li-link1, .li-link2 {
+  display: block !important;
+}
+
+#chevron {
+  display: inline;
+}
+#chevron.show {
+  transform: rotate(-180deg);
+}
+
+.collapsing {
+  -webkit-transition: none;
+  transition: none;
+  display: none;
+}
+
+
+
+
+
+
+
+
+
 .menu-logo {
   margin-right: 10px;
   height: 37px;

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -1,3 +1,11 @@
+@media (max-width: 991px) {
+  .body-top-padding {
+    padding-top: 0px !important;
+}
+
+
+
+
 
 /* MOBILE NAVBAR */
 

--- a/ui/src/app/shared/layout/layout.component.scss
+++ b/ui/src/app/shared/layout/layout.component.scss
@@ -49,7 +49,7 @@
 .navbar-toggler.collapsed .top-bar {
   position: absolute !important;
   top: 0px !important;
-  transform: rotate(0deg) !important
+  transform: rotate(0deg) !important;
 }
 
 .navbar-toggler.collapsed .middle-bar {


### PR DESCRIPTION
- [x] added sidebar (for now without moving links!)
- [x] hamburger menu animation

What definitely needs to be done:
- [ ] match colors
- [ ] on the Status page, after opening the menu, the width of the content does not change (on other pages it adjusts)
- [ ] inserting appropriate links (for now there are only dummies in the sidebar)
- [ ] organizing the mobile menu (but that's only at the end)

P.S: Sidebar and menu on mobile It's two separate menus. Sidebar appears on screen >= 992 px, mobile menu on smaller.

<img width="1464" alt="Zrzut ekranu 2023-11-20 o 14 11 07" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/b5dcf6e8-3081-4f72-8ee7-0e1cf52a8348">
<img width="1451" alt="Zrzut ekranu 2023-11-20 o 14 12 28" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/be8b0845-5dca-4f40-a6ba-f89377c7cb03">
<img width="1461" alt="Zrzut ekranu 2023-11-20 o 14 12 45" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/4eb3b761-3892-41da-b733-cd26665ec376">
