### PR TITLE
fix widget to show all 4 info

### DIFF
--- a/ui/src/app/modules/status/widgets/homebridge-status-widget/homebridge-status-widget.component.scss
+++ b/ui/src/app/modules/status/widgets/homebridge-status-widget/homebridge-status-widget.component.scss
@@ -1,5 +1,7 @@
 .hb-status-icon {
-  font-size: 40px;
+  font-size: 35px !important;
+  padding-top: 2px !important;
+  padding-bottom: 2px !important;
 }
 
 .hb-status-item {


### PR DESCRIPTION
From (you need to scroll down to see plugins) :
<img width="345" alt="Zrzut ekranu 2023-11-22 o 10 50 46" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/0fa5828d-59b4-4c96-855d-3f34c6974033">


To:
<img width="344" alt="Zrzut ekranu 2023-11-22 o 10 50 39" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/9635f73f-c8d3-40c5-ad05-863a6ab4c38a">
