### PR TITLE
Truncate Plugin name to 2 lines

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.scss
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.scss
@@ -6,3 +6,13 @@
 .dropup .dropdown-toggle:after {
   display: none;
 }
+
+.card-title {
+  -webkit-line-clamp: 2 !important;
+  -webkit-box-orient: vertical !important;
+  display: -webkit-box !important;
+  overflow: hidden !important;
+  height: 4rem !important;
+  line-height: 2rem !important;
+  max-height: 4rem !important;
+}


### PR DESCRIPTION
From (as you can see if plugin name is long):
<img width="931" alt="Zrzut ekranu 2023-11-23 o 15 25 45" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/5738a854-69c0-47d9-a3c3-eddb4eb05fb5">


To:
<img width="929" alt="Zrzut ekranu 2023-11-23 o 15 25 14" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/e50104c4-fe84-4c2d-9251-2df1b1b1c8bb">
