### PR TITLE
Plugin card - plugin name

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -6,8 +6,8 @@
     </div>
     <div class="d-flex flex-column justify-content-between w-100">
       <h4 class="card-title truncate2 mt-0 mb-0">
-        {{ plugin.displayName || ((plugin.name.charAt(0) === '@' ? plugin.name.split('/')[1] : plugin.name) |
-        replace:'-':' ' | titlecase) }}
+        {{ plugin.displayName | replace:'Homebridge':'' || ((plugin.name.charAt(0) === '@' ? plugin.name.split('/')[1] : plugin.name) |
+        replace:'-':' ' | replace:'Homebridge':'' | titlecase) }}
       </h4>
       
       <div class="d-flex flex-row justify-content-start mb-0 mt-2">


### PR DESCRIPTION
Hide word "Homebridge" from plugin name (only in plugin card title). Every plugin name starts with "Homebridge"...