### PR TITLE
Fix hb-service start indent in manage-plugins-modal.component.html

### DIFF
--- a/ui/src/app/core/manage-plugins/manage-plugins-modal/manage-plugins-modal.component.html
+++ b/ui/src/app/core/manage-plugins/manage-plugins-modal/manage-plugins-modal.component.html
@@ -38,7 +38,7 @@
       </p>
       <pre class="p-2" style="background-color: #efefef;">hb-service stop
 npm install -g {{ pluginName }}@{{targetVersion}}
-        hb-service start</pre>
+hb-service start</pre>
     </div>
   </div>
   <div *ngIf="showReleaseNotes && !actionComplete" class="modal-body plugin-modal-body">


### PR DESCRIPTION
## :recycle: Current situation
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/f71bccbb-d196-446f-a14b-dac9213d792a)

## :bulb: Proposed solution
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/f0819472-ee73-48cd-aed8-2adb195fa8fb)

