### PR TITLE
Hide homebridge word from plugin card

### DIFF
--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.html
@@ -7,7 +7,7 @@
     <div class="d-flex flex-column justify-content-between w-100">
       <h4 class="card-title truncate2 mt-0 mb-0">
         {{ (plugin.displayName || ((plugin.name.charAt(0) === '@' ? plugin.name.split('/')[1] : plugin.name) |
-        replace:'-':' ' | titlecase)) | replace:'Homebridge':'' }}
+        replace:'-':' ' | titlecase)) | replace:'Homebridge':'' | replace:'homebridge':'' }}
       </h4>
 
       <div class="d-flex flex-row justify-content-start mb-0 mt-2">


### PR DESCRIPTION
The previous PR works. But it only hides the word Homebridge and the word homebridge (starting with a small letter) don't hide. This should fix this. 