### PR TITLE
Fix for urls extending beyond text box on small screen sizes (in manage-plugins-modal.component.html)

### DIFF
--- a/ui/src/app/core/manage-plugins/manage-plugins-modal/manage-plugins-modal.component.html
+++ b/ui/src/app/core/manage-plugins/manage-plugins-modal/manage-plugins-modal.component.html
@@ -44,7 +44,7 @@ hb-service start</pre>
   <div *ngIf="showReleaseNotes && !actionComplete" class="modal-body plugin-modal-body">
     <h5 *ngIf="!updateToBeta">{{ 'plugins.manage.label_release_notes' | translate }} <span *ngIf="release.name">({{ release.name }})</span></h5>
     <h5 *ngIf="updateToBeta">{{ 'plugins.manage.label_release_notes_beta' | translate }} <span *ngIf="release.name">({{ release.name }})</span></h5>
-    <div class="alert show alert-info pt-3 px-3 pb-0 mb-0">
+    <div class="alert show alert-info pt-3 px-3 pb-0 mb-0" style="word-wrap: break-word;">
       <markdown class="plugin-md" [data]="release.changelog"></markdown>
     </div>
   </div>


### PR DESCRIPTION
## :recycle: Current situation
Add wordwrap to the beta version block of text to prevent the urls from going outside the text box
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/6f0f561e-b1b9-4a01-a10a-e7b1ca81573a)


## :bulb: Proposed solution
![image](https://github.com/homebridge/homebridge-config-ui-x/assets/59387202/5f2e9eff-20a6-49e6-b62e-38699e67676d)

