### PR TITLE
Add UUID to accessory info modal

### DIFF
--- a/ui/src/app/core/accessories/info-modal/info-modal.component.html
+++ b/ui/src/app/core/accessories/info-modal/info-modal.component.html
@@ -31,6 +31,10 @@
     <table class="table table-borderless table-hover table-striped table-sm" style="table-layout: fixed; width:100%; word-wrap: break-word;">
       <tbody>
         <tr>
+          <td>UUIDe</td>
+          <td class="text-right">{{ service.UUID }}</td>
+        </tr>
+        <tr>
           <th>{{ service.humanType }}</th>
           <td class="text-right"></td>
         </tr>

--- a/ui/src/app/core/accessories/info-modal/info-modal.component.html
+++ b/ui/src/app/core/accessories/info-modal/info-modal.component.html
@@ -31,8 +31,8 @@
     <table class="table table-borderless table-hover table-striped table-sm" style="table-layout: fixed; width:100%; word-wrap: break-word;">
       <tbody>
         <tr>
-          <td>UUIDe</td>
-          <td class="text-right">{{ service.UUID }}</td>
+          <td>UUID</td>
+          <td class="text-right">{{ service.uuid }}</td>
         </tr>
         <tr>
           <th>{{ service.humanType }}</th>


### PR DESCRIPTION
UUID is displayed in "remove accessory from cache" but not displayed in accessory info.