### PR TITLE
Fix too long label in windowcovering.component.html

### DIFF
--- a/ui/src/app/core/accessories/types/windowcovering/windowcovering.component.html
+++ b/ui/src/app/core/accessories/types/windowcovering/windowcovering.component.html
@@ -9,7 +9,7 @@
     <div class="accessory-label grey-text" *ngIf="service.values.PositionState === 2">
       <span *ngIf="service.values.CurrentPosition === 0">{{ 'accessories.control.label_closed' | translate }}</span>
       <span *ngIf="service.values.CurrentPosition > 0 && service.values.CurrentPosition < 100">
-        {{ service.values.CurrentPosition }}% {{ 'accessories.control.label_open' | translate }}
+        {{ service.values.CurrentPosition }}%
       </span>
       <span *ngIf="service.values.CurrentPosition === 100">{{ 'accessories.control.label_open' | translate }}</span>
     </div>


### PR DESCRIPTION
![2250F055-F520-4876-A112-A3C473F324F3](https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/eca58aa2-205a-4ba3-8c36-caba2e126847)
