### PR TITLE
Fix for backup service including npm's cache, and therefore being too large to upload generating a zlib error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to homebridge-config-ui-x will be documented in this file.
 
-## 4.54.2 (2023-12-18)
-
-### Bug Fixes
-
-- Fix for backups including npm's cache, and therefore being too large to upload and restore.
-
 ## 4.54.1 (2023-12-08)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to homebridge-config-ui-x will be documented in this file.
 
+## 4.54.2 (2023-12-18)
+
+### Bug Fixes
+
+- Fix for backups including npm's cache, and therefore being too large to upload and restore.
+
 ## 4.54.1 (2023-12-08)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-config-ui-x",
-  "version": "4.54.2",
+  "version": "4.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-config-ui-x",
-      "version": "4.54.2",
+      "version": "4.54.1",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-config-ui-x",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-config-ui-x",
-      "version": "4.54.1",
+      "version": "4.54.2",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-config-ui-x",
   "displayName": "Homebridge UI",
-  "version": "4.54.2",
+  "version": "4.54.1",
   "description": "A web based management, configuration and control platform for Homebridge.",
   "license": "MIT",
   "author": "oznu <dev@oz.nu>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-config-ui-x",
   "displayName": "Homebridge UI",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "description": "A web based management, configuration and control platform for Homebridge.",
   "license": "MIT",
   "author": "oznu <dev@oz.nu>",

--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -114,6 +114,7 @@ export class BackupService {
             'package.json',       // npm
             'package-lock.json',  // npm
             '.npmrc',             // npm
+            '.npm',               // npm
             'FFmpeg',             // ffmpeg
             'fdk-aac',            // ffmpeg
             '.git',               // git


### PR DESCRIPTION
Fix for backups including npm's cache, and therefore being too large to upload and restore.

closes #1856 

## :recycle: Current situation
 
see #1856 

## :bulb: Proposed solution

add '.npm' folder to ignored files/folders list


## :gear: Release Notes
### Bug Fixes
- Fix for backups including npm's cache, and therefore being too large to upload and restore
## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

I was finally able to backup and restore successfully with this change.

