### PR TITLE
Fix for backup service including npm's cache, and therefore being too…

### DIFF
--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -114,6 +114,7 @@ export class BackupService {
             'package.json',       // npm
             'package-lock.json',  // npm
             '.npmrc',             // npm
+            '.npm',               // npm
             'FFmpeg',             // ffmpeg
             'fdk-aac',            // ffmpeg
             '.git',               // git


### PR DESCRIPTION
Fix for backups including npm's cache, and therefore being too large to upload and restore.

closes #1856 

## :recycle: Current situation
 
see #1856 

## :bulb: Proposed solution

add '.npm' folder to ignored files/folders list


## :gear: Release Notes
### Bug Fixes
- Fix for backups including npm's cache, and therefore being too large to upload and restore
## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

I was finally able to backup and restore successfully with this change.

