### PR TITLE
Update remove-single-cached-accessory-modal.component.html - add warning to alert

### DIFF
--- a/ui/src/app/modules/settings/remove-single-cached-accessory-modal/remove-single-cached-accessory-modal.component.html
+++ b/ui/src/app/modules/settings/remove-single-cached-accessory-modal/remove-single-cached-accessory-modal.component.html
@@ -10,7 +10,11 @@
   </div>
   <div class="modal-body">
     <ngb-alert type="info" [dismissible]="false">
-      {{ 'reset.message_remove_cached_accessories_single_warning' | translate }}
+      <p>{{ 'reset.message_remove_cached_accessories_single_warning' | translate }}</p>
+      <p [translate]="'reset.accessories_will_may_need_to_be_reconfigured'">
+        After performing this action some accessories may need to be reconfigured in HomeKit or re-added to your
+        automations.
+      </p>
     </ngb-alert>
 
     <ul class="list-group mt-2">


### PR DESCRIPTION
Adding the same warning that appears before removing all devices from the cache - about the fact that you may need to reconfigure the device in HomeKit and / or in automations.

<img width="793" alt="Zrzut ekranu 2024-01-10 o 12 27 22" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/323592b8-b246-42b3-a1b2-9f3b6f097596">
