### PR TITLE
break-word in plugin config

### DIFF
--- a/ui/src/scss/base/layout.scss
+++ b/ui/src/scss/base/layout.scss
@@ -26,6 +26,7 @@ a:hover {
 
 .help-block {
   color: #9e9e9e !important;
+  word-break: break-word;
 }
 
 .card .card-text {


### PR DESCRIPTION
FROM:
<img width="383" alt="Zrzut ekranu 2024-01-29 o 12 35 04" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/439f5c03-4e4c-4724-8b8d-f0ed377e35c9">


TO:
<img width="350" alt="Zrzut ekranu 2024-01-29 o 12 34 46" src="https://github.com/homebridge/homebridge-config-ui-x/assets/82271669/9cdc680d-903f-46ef-844c-1158a8b50089">
