### PR TITLE
Fix crash with missing homepage package.json property

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -894,7 +894,7 @@ export class PluginsService {
     }
 
     // make sure the repo is GitHub
-    const repoMatch = plugin.links.homepage.match(/https:\/\/github.com\/([^\/]+)\/([^\/#]+)/);
+    const repoMatch = plugin.links.homepage?.match(/https:\/\/github.com\/([^\/]+)\/([^\/#]+)/);
     const bugsMatch = plugin.links.bugs?.match(/https:\/\/github.com\/([^\/]+)\/([^\/#]+)/);
     let match: RegExpMatchArray | null = repoMatch;
     if (!repoMatch) {


### PR DESCRIPTION
## :recycle: Current situation

Currently, fetching the update release notes crashes if the plugin does not have a `homepage` property defined in the `package.json`.

testing locally against my plugin
![Screenshot 2024-02-21 at 12 44 14 PM](https://github.com/homebridge/homebridge-config-ui-x/assets/395354/e6acd5f8-6fe2-4982-8e5c-99ea5a8a3b7b)

Looks to have been introduced in https://github.com/homebridge/homebridge-config-ui-x/pull/1890

## :bulb: Proposed solution

Ensure `plugin.links.homepage` exists before attempting to use it. We short-circuit above if both `homepage` and `bugs` don't exist, but after that, we are in a state where either both exist, or just one does.

with this change, the release notes render, even without the `homepage` property
![Screenshot 2024-02-21 at 12 54 59 PM](https://github.com/homebridge/homebridge-config-ui-x/assets/395354/90886328-19cb-4af2-be12-21b65f3882b4)
