### PR TITLE
Check that `pkg.maintainers` is defined before checking it's length

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -366,7 +366,7 @@ export class PluginsService {
         homepage: pkg.homepage,
         bugs: typeof pkg.bugs === 'object' && pkg.bugs?.url ? pkg.bugs.url : null,
       };
-      plugin.author = (pkg.maintainers.length) ? pkg.maintainers[0].name : null;
+      plugin.author = (pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null;
       plugin.verifiedPlugin = this.verifiedPlugins.includes(pkg.name);
       plugin.verifiedPlusPlugin = this.verifiedPlusPlugins.includes(pkg.name);
       plugin.icon = this.pluginIcons[pkg.name]
@@ -1322,7 +1322,7 @@ export class PluginsService {
         homepage: pkg.homepage,
         bugs: typeof pkg.bugs === 'object' && pkg.bugs?.url ? pkg.bugs.url : null,
       };
-      plugin.author = (pkg.maintainers.length) ? pkg.maintainers[0].name : null;
+      plugin.author = (pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null;
       plugin.engines = pkg.engines;
     } catch (e) {
       if (e.response?.status !== 404) {


### PR DESCRIPTION
## :recycle: Current situation

For some reason, NPM doesn't seem to be setting the `maintainers` key on packages in the registry right now. I only noticed this because I was seeing this error in the Homebridge UI after publishing an update to a package:

```
[6/20/2024, 6:17:45 PM] [Homebridge UI] [homebridge-fujitsu-airstage] Failed to check registry.npmjs.org for updates: "Cannot read properties of undefined (reading 'length')" - see https://homebridge.io/w/JJSz6 for help.
```

## :bulb: Proposed solution

Check that `pkg.maintainers` is defined before checking it's length