### PR TITLE
Temporarily add `maintainers` to `package.json` to handle NPM schema change

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,5 +158,43 @@
     "accessory control",
     "smart home",
     "hb-service"
+  ],
+  "maintainers": [
+    {
+      "email": "bwp91@icloud.com",
+      "name": "bwp91"
+    },
+    {
+      "email": "dev@oz.nu",
+      "name": "oznu"
+    },
+    {
+      "email": "buyminivan-northern@yahoo.ca",
+      "name": "northernman"
+    },
+    {
+      "email": "mail@anderl-bauer.de",
+      "name": "supereg"
+    },
+    {
+      "email": "khaos.tian@gmail.com",
+      "name": "khaost"
+    },
+    {
+      "email": "erik.baauw@xs4all.nl",
+      "name": "ebaauw"
+    },
+    {
+      "email": "donavan.becker@icloud.com",
+      "name": "donavanbecker"
+    },
+    {
+      "email": "dustin.greif@gmail.com",
+      "name": "dustin.greif"
+    },
+    {
+      "email": "nfarina@gmail.com",
+      "name": "nfarina"
+    }
   ]
 }


### PR DESCRIPTION
## :recycle: Current situation

NPM stopped returning the `maintainers` key from the registry when viewing a versioned package. Is this intentional? Nobody knows. I have a support ticket open with NPM since last Thursday, and [the thread on GitHub Communities](https://github.com/orgs/community/discussions/129220) hasn't seen a response. This change has prevented the Homebridge UI from showing a plugin's author, as well as showing users that there is a Homebridge UI update from within Homebridge.

## :bulb: Proposed solution

Unfortunately, users will not see that there are Homebridge UI updates until `maintainers` is manually added to `package.json`. This key is supposed to be set by NPM themselves, but it appears that you can set it yourself. I copied the `maintainers` from the top-level package metadata [here](https://registry.npmjs.org/homebridge-config-ui-x). This change can eventually be reverted if NPM starts setting `maintainers` in the versioned package metadata again, or if #2079 is merged, and some amount of time has passed to ensure users have updated their Homebridge UI.