### PR TITLE
fix: EventEmitter memory leak warnings when you have a significant number of child bridges.

### DIFF
--- a/src/modules/child-bridges/child-bridges.service.ts
+++ b/src/modules/child-bridges/child-bridges.service.ts
@@ -38,15 +38,19 @@ export class ChildBridgesService {
       client.emit('child-bridge-status-update', data);
     };
 
+    this.homebridgeIpcService.setMaxListeners(this.homebridgeIpcService.getMaxListeners() + 1);
     this.homebridgeIpcService.on('childBridgeStatusUpdate', listener);
 
     // cleanup on disconnect
     const onEnd = () => {
       client.removeAllListeners('end');
       client.removeAllListeners('disconnect');
+      client.setMaxListeners(client.getMaxListeners() - 2);
       this.homebridgeIpcService.removeListener('childBridgeStatusUpdate', listener);
+      this.homebridgeIpcService.setMaxListeners(this.homebridgeIpcService.getMaxListeners() - 1);
     };
 
+    client.setMaxListeners(client.getMaxListeners() + 2);
     client.on('end', onEnd.bind(this));
     client.on('disconnect', onEnd.bind(this));
   }


### PR DESCRIPTION
## :recycle: Current situation

If you use something like Home Manager on iOS and you have a significant number of child bridges, several IPC connections will be opened and they’ll easily exceed the default event limit, triggering a Node warning like:

```

(node:6868) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnect listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
(node:6868) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 childBridgeStatusUpdate listeners added to [HomebridgeIpcService]. Use emitter.setMaxListeners() to increase limit
(node:6868) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit
(node:6868) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 childBridgeMetadataResponse listeners added to [HomebridgeIpcService]. Use emitter.setMaxListeners() to increase limit
(node:6868) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 childBridgeMetadataResponse listeners added to [HomebridgeIpcService]. Use emitter.setMaxListeners() to increase limit
```
## :bulb: Proposed solution

This PR addresses those by increasing and decreasing the limits dynamically.

## :gear: Release Notes

fix: EventEmitter memory leak warnings when using multiple child bridges utilize the IPC connection.

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
