### PR TITLE
Fix for backups including cache, and therefore being too large to upload and restore.

### DIFF
--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -124,6 +124,7 @@ export class BackupService {
             '#recycle',           // synology dsm recycle bin
             '@eaDir',             // synology dsm metadata
             '.venv',              // python venv
+            '.cache',             // cache
           ].includes(basename(filePath))) {
             return false;
           }


### PR DESCRIPTION
## :recycle: Current situation

similar to https://github.com/homebridge/homebridge-config-ui-x/issues/1856 the same thing happens when the `.cache` folder is very big in my case the uncompressed backup had 300 MB. node-gyp was the only thing in the folder

## :bulb: Proposed solution

add '.cache' folder to ignored files/folders list

## :gear: Release Notes

**Bug Fixes**
- Fix for backups including cache, and therefore being too large to upload and restore

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

