### PR TITLE
Backup name with date

### DIFF
--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -89,8 +89,9 @@ export class BackupService {
     // prepare a temp working directory
     const instanceId = this.configService.homebridgeConfig.bridge.username.replace(/:/g, '');
     const backupDir = await mkdtemp(join(tmpdir(), 'homebridge-backup-'));
-    const backupFileName = 'homebridge-backup' + '-' + instanceId
-      + new Date().toISOString().slice(0,19).replaceAll("-","").replaceAll(":","") + '.tar.gz';
+    const backupFileName = 'homebridge-backup' + '-' + instanceId + '-'
+      + new Date().toISOString().slice(0,19).replaceAll('-', '').replaceAll(':', '').replace('T', '-') 
+      + '.tar.gz';
     const backupPath = resolve(backupDir, backupFileName);
 
     this.logger.log(`Creating temporary backup archive at ${backupPath}`);
@@ -227,8 +228,9 @@ export class BackupService {
       const { backupDir, backupPath, instanceId } = await this.createBackup();
       await copy(backupPath, resolve(
         this.configService.instanceBackupPath,
-        'homebridge-backup-' + instanceId + '.'
-        + new Date().toISOString().slice(0,19).replaceAll("-","").replaceAll(":","") + '.tar.gz',
+        'homebridge-backup' + '-' + instanceId + '-'
+        + new Date().toISOString().slice(0,19).replaceAll('-', '').replaceAll(':', '').replace('T', '-')
+        + '.tar.gz',
       ));
       await remove(resolve(backupDir));
     } catch (e) {

--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -89,7 +89,8 @@ export class BackupService {
     // prepare a temp working directory
     const instanceId = this.configService.homebridgeConfig.bridge.username.replace(/:/g, '');
     const backupDir = await mkdtemp(join(tmpdir(), 'homebridge-backup-'));
-    const backupFileName = 'homebridge-backup' + '-' + instanceId + '.tar.gz';
+    const backupFileName = 'homebridge-backup' + '-' + instanceId
+      + new Date().toISOString().slice(0,19).replaceAll("-","").replaceAll(":","") + '.tar.gz';
     const backupPath = resolve(backupDir, backupFileName);
 
     this.logger.log(`Creating temporary backup archive at ${backupPath}`);
@@ -226,7 +227,8 @@ export class BackupService {
       const { backupDir, backupPath, instanceId } = await this.createBackup();
       await copy(backupPath, resolve(
         this.configService.instanceBackupPath,
-        'homebridge-backup-' + instanceId + '.' + new Date().getTime().toString() + '.tar.gz',
+        'homebridge-backup-' + instanceId + '.'
+        + new Date().toISOString().slice(0,19).replaceAll("-","").replaceAll(":","") + '.tar.gz',
       ));
       await remove(resolve(backupDir));
     } catch (e) {


### PR DESCRIPTION
- change backup name in scheduled backups , currently it contains timestamp, i propose more friendly date: yyyymmdd-hhmmss, e.g.:  `20240801-205532` - here you can easily read when backup was made. 
- Also add date in same format to backup creating manualy by user. 

Date is in UTC time zone.