### PR TITLE
Little space between rows in Terminal and Logs

### DIFF
--- a/ui/src/scss/components/terminal.scss
+++ b/ui/src/scss/components/terminal.scss
@@ -14,3 +14,7 @@
   scrollbar-width: none; // firefox
   -ms-overflow-style: none; // edge
 }
+
+.xterm span {
+  padding-bottom: 5px;;
+}


### PR DESCRIPTION
- Add little space between rows
- Unfortunately, I did not find a way to add additional space between messages (not rows, the message can have several rows).