### PR TITLE
Add `log.maxSize`/`log.truncateSize` options

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -524,6 +524,16 @@
               "functionBody": "return (model.log && model.log.method==='file')"
             }
           },
+          "maxSize": {
+            "type": "integer",
+            "description": "The max log size (bytes). Set to -1 to disable log truncation.",
+            "minimum": -1
+          },
+          "truncateSize": {
+            "type": "integer",
+            "description": "The size (bytes) to truncate the log to once it goes over `maxSize`.",
+            "minimum": 0
+          },
           "service": {
             "title": "Systemd Service",
             "type": "string",
@@ -717,6 +727,8 @@
             "debug",
             "log.method",
             "log.path",
+            "log.maxSize",
+            "log.truncateSize",
             "log.service",
             "log.command",
             "log.tail",


### PR DESCRIPTION
## :recycle: Current situation

I'd like more of the log to be kept.

## :bulb: Proposed solution

Add some more options to make it configurable.

![image](https://github.com/user-attachments/assets/779b261f-2618-49da-97c2-97b7cab93cda)

closes #2098

## :gear: Release Notes

- Adds new `log.maxSize`/`log.truncateSize` config options to control log truncation.

### Testing

I've tested it manually locally and the new values are picked up in the code. Please let me know if there are any automated tests I could update/add for this.