### PR TITLE
support plugins with dots in their @scope

### DIFF
--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -1353,7 +1353,7 @@ export class HomebridgeServiceHelper {
       process.exit(1);
     }
 
-    if (!target.name.match(/^((@[\w-]*)\/)?(homebridge-[\w-]*)$/)) {
+    if (!target.name.match(/^(@[\w-]+(\.[\w-]+)*\/)?homebridge-[\w-]+$/)) {
       this.logger('Invalid plugin name.', 'fail');
       process.exit(1);
     }

--- a/src/modules/plugins/plugins.dto.ts
+++ b/src/modules/plugins/plugins.dto.ts
@@ -25,7 +25,7 @@ export class PluginActionDto {
   @IsDefined()
   @IsNotEmpty()
   @IsString()
-  @Matches(/^((@[\w-]*)\/)?(homebridge-[\w-]*)$/)
+  @Matches(/^(@[\w-]+(\.[\w-]+)*\/)?homebridge-[\w-]+$/)
     name: string;
 
   @IsOptional()

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -66,7 +66,7 @@ import { HomebridgePluginUiMetadata, HomebridgePluginVersions, PluginAlias } fro
 
 @Injectable()
 export class PluginsService {
-  private static readonly PLUGIN_IDENTIFIER_PATTERN = /^((@[\w-]*)\/)?(homebridge-[\w-]*)$/;
+  private static readonly PLUGIN_IDENTIFIER_PATTERN = /^(@[\w-]+(\.[\w-]+)*\/)?homebridge-[\w-]+$/;
 
   private npm: Array<string> = this.getNpmPath();
   private paths: Array<string> = this.getBasePaths();


### PR DESCRIPTION
## :recycle: Current situation

I'm writing a plugin and my npm @scope has a '.' in it. Homebridge won't load it.

## :bulb: Proposed solution

Changing PLUGIN_IDENTIFIER_PATTERN and friends to include a period in the regex.

## :gear: Release Notes

Support plugins with dots in their https://github.com/scope

## :heavy_plus_sign: Additional Information

N/A

### Testing

### Reviewer Nudging
