### PR TITLE
Removed conditional for displaying search exit component

### DIFF
--- a/ui/src/app/modules/plugins/plugins.component.html
+++ b/ui/src/app/modules/plugins/plugins.component.html
@@ -16,7 +16,7 @@
         formControlName="query"
       />
       <a class="hb-npm-search-clear" href="javascript:void(0)" (click)="onClearSearch()">
-        <i class="far fa-fw fa-times-circle" *ngIf="form.controls['query'].value"></i>
+        <i class="far fa-fw fa-times-circle"></i>
       </a>
     </form>
   </div>

--- a/ui/src/app/modules/plugins/plugins.component.html
+++ b/ui/src/app/modules/plugins/plugins.component.html
@@ -15,7 +15,7 @@
         [placeholder]="'plugins.placeholder_search_plugin' | translate"
         formControlName="query"
       />
-      <a class="hb-npm-search-clear" href="javascript:void(0)" (click)="onClearSearch()">
+      <a class="hb-npm-search-clear" href="javascript:void(0)" (click)="onClearSearch()" *ngIf="showExitButton">
         <i class="far fa-fw fa-times-circle"></i>
       </a>
     </form>

--- a/ui/src/app/modules/plugins/plugins.component.ts
+++ b/ui/src/app/modules/plugins/plugins.component.ts
@@ -17,6 +17,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
   public loading = true
   public installedPlugins: any = []
   public childBridges = []
+  public showExitButton = false
   public form = new FormGroup({
     query: new FormControl('', [Validators.required]),
   })
@@ -73,7 +74,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
 
   async loadInstalledPlugins() {
     this.form.setValue({ query: '' })
-
+    this.showExitButton = false
     this.installedPlugins = []
     this.loading = true
 
@@ -155,6 +156,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
   search() {
     this.installedPlugins = []
     this.loading = true
+    this.showExitButton = true
 
     this.$api.get(`/plugins/search/${encodeURIComponent(this.form.value.query)}`).subscribe({
       next: (data) => {
@@ -172,7 +174,6 @@ export class PluginsComponent implements OnInit, OnDestroy {
   }
 
   onClearSearch() {
-    this.form.setValue({ query: '' })
     this.loadInstalledPlugins()
   }
 


### PR DESCRIPTION
## :recycle: Current situation

[Can't exit plugin Search mode when search term is empty #2248](https://github.com/homebridge/homebridge-config-ui-x/issues/2248)

## :bulb: Proposed solution

Always display search exit component.

Clicking the exit Search component when no search term provided causes the currently displayed plugins to be redisplayed. This behavior is no different than placing the cursor on the Search textbox and pressing enter with no search term specified.

## :gear: Release Notes

Removed conditional from display of search exit component.

## :heavy_plus_sign: Additional Information


### Testing


### Reviewer Nudging
