### PR TITLE
Show Homebridge & Homebridge UI versions in Update Center (beta)

### DIFF
--- a/ui/src/app/modules/status/widgets/update-centre-widget/update-centre-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-centre-widget/update-centre-widget.component.html
@@ -31,7 +31,7 @@
             @if (!homebridgePkg.installedVersion) {
             <span> {{ 'status.homebridge.checking' | translate }} </span>
             } @if (homebridgePkg.installedVersion && !homebridgePkg.updateAvailable) {
-            <span> {{ 'status.homebridge.up_to_date' | translate }} </span>
+            <span> v{{ $settings.env.homebridgeVersion }} </span>
             } @if (homebridgePkg.installedVersion && homebridgePkg.updateAvailable) {
             <a
               href="javascript:void(0)"
@@ -72,7 +72,7 @@
             @if (!homebridgeUiPkg.installedVersion) {
             <span> {{ 'status.homebridge.checking' | translate }} </span>
             } @if (homebridgeUiPkg.installedVersion && !homebridgeUiPkg.updateAvailable) {
-            <span> {{ 'status.homebridge.up_to_date' | translate }} </span>
+            <span> v{{ $settings.env.homebridgeUiVersion }} </span>
             } @if (homebridgeUiPkg.installedVersion && homebridgeUiPkg.updateAvailable) {
             <a
               href="javascript:void(0)"
@@ -144,7 +144,7 @@
             {{ 'status.widget.info.node_unsupp' | translate }}
           </a>
           } @if (nodejsStatusDone && !nodejsInfo.updateAvailable && !nodejsInfo.showNodeUnsupportedWarning) {
-          <span class="grey-text small"> {{ 'status.homebridge.up_to_date' | translate }} </span>
+          <span class="grey-text small"> v{{ $settings.env.nodeVersion }} </span>
           }
         </div>
       </div>


### PR DESCRIPTION
## :recycle: Current situation

See [Show Homebridge and Homebridge UI versions in update center](https://github.com/homebridge/homebridge-config-ui-x/issues/2273)

## :bulb: Proposed solution

Code changes for [Show Homebridge and Homebridge UI versions in update center](https://github.com/homebridge/homebridge-config-ui-x/issues/2273)

## :heavy_plus_sign: Additional Information

PR on branch `beta-5.0.0`
