### PR TITLE
Removed Node version from System Information widget

### DIFF
--- a/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.html
@@ -54,10 +54,6 @@
           <td>{{ serverInfo.serviceUser }}</td>
         </tr>
         <tr>
-          <th scope="row" class="text-nowrap">{{ 'status.widget.info.nodejs_version' | translate }}</th>
-          <td>{{ serverInfo.nodeVersion }}</td>
-        </tr>
-        <tr>
           <th scope="row" class="text-nowrap">{{ 'status.widget.info.nodejs_path' | translate }}</th>
           <td>{{ nodejsInfo.installPath }}</td>
         </tr>


### PR DESCRIPTION
## :recycle: Current situation

See [Node.js information displayed in separate areas](https://github.com/homebridge/homebridge-config-ui-x/issues/2274)

## :bulb: Proposed solution

Code changes for [Node.js information displayed in separate areas](https://github.com/homebridge/homebridge-config-ui-x/issues/2274)

## :heavy_plus_sign: Additional Information

PR on branch `beta-5.0.0`

### Note:
This PR should only be applied along with PR [Show Homebridge & Homebridge UI versions in Update Center (beta)](https://github.com/homebridge/homebridge-config-ui-x/pull/2277)
