### PR TITLE
Changed spelling from Centre -> Center

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -417,7 +417,7 @@
   "status.plugins_out_of_date": "Updates Available",
   "status.services.label_not_running": "Not running",
   "status.services.label_running": "Running",
-  "status.services.updates": "Update Centre",
+  "status.services.updates": "Update Center",
   "status.uptime.title_uptime": "Uptime",
   "status.widget.accessories.choose_accessories": "Choose the accessories to display in this widget from the Accessories tab.",
   "status.widget.add.label_pairing_code": "Pairing Code",


### PR DESCRIPTION
## :recycle: Current situation

Center was misspelled  😁
