### PR TITLE
Added default values to Advanced Settings UI form and updated value change check

### DIFF
--- a/ui/src/app/modules/settings/settings.component.ts
+++ b/ui/src/app/modules/settings/settings.component.ts
@@ -31,6 +31,11 @@ export class SettingsComponent implements OnInit {
 
   public originalUiSettingsForm = {
     port: 0,
+    // Default values
+    auth: 'form',
+    theme: 'auto',
+    tempUnits: 'c',
+    lang: 'auto',
   }
 
   public originalLoginWallpaper = ''
@@ -104,14 +109,12 @@ export class SettingsComponent implements OnInit {
       port: this.$settings.env.port,
     })
     this.uiSettingsForm.valueChanges.pipe(debounceTime(500)).subscribe((data) => {
-      let hasChangedUiSettings = false
       Object.keys(data).forEach((key) => {
-        if (this.originalUiSettingsForm[key] !== data[key]) {
-          this.saveUiSettingChange(key, data[key])
-          hasChangedUiSettings = true
-        }
+        const newValue = (data[key] === undefined || data[key] === '') ? this.originalUiSettingsForm[key] : data[key];
+        this.saveUiSettingChange(key, data[key])
+        hasChangedUiSettings = true
       })
-      this.hasChangedUiSettings = hasChangedUiSettings
+      this.hasChangedUiSettings = true;
     })
   }
 


### PR DESCRIPTION
## :recycle: Current situation

See [Unable to save on UI Advanced Settings form](https://github.com/homebridge/homebridge-config-ui-x/issues/2256)

## :bulb: Proposed solution

Code changes for [Unable to save on UI Advanced Settings form](https://github.com/homebridge/homebridge-config-ui-x/issues/2256)

## :heavy_plus_sign: Additional Information

**NOTE:** This is an issue that will affect all the users that installed Homebridge UI prior to the `beta-5.0.0` form validation changes and that accepted the default Settings & Advanced Settings values.