### PR TITLE
Reverted search URL and added filter to results

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -307,6 +307,7 @@ export class PluginsService {
     // Filter matching plugins
     const matchPlugins = results.filter(
       plugin => (
+        plugin.keywords.some(keyword => keyword.includes(query)) ||
         searchTerms.some(term => plugin.name.includes(term)) ||
         searchTerms.some(term => plugin.keywords.includes(term))
       )
@@ -375,7 +376,7 @@ export class PluginsService {
         bugs: typeof pkg.bugs === 'object' && pkg.bugs?.url ? pkg.bugs.url : null,
       }
       plugin.author = this.scopedPlugins[pkg.name]
-      || ((pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null)
+        || ((pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null)
       plugin.verifiedPlugin = this.verifiedPlugins.includes(pkg.name)
       plugin.verifiedPlusPlugin = this.verifiedPlusPlugins.includes(pkg.name)
       plugin.icon = this.pluginIcons[pkg.name]
@@ -743,7 +744,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))
@@ -1340,7 +1341,7 @@ export class PluginsService {
         bugs: typeof pkg.bugs === 'object' && pkg.bugs?.url ? pkg.bugs.url : null,
       }
       plugin.author = this.scopedPlugins[pkg.name]
-      || ((pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null)
+        || ((pkg.maintainers && pkg.maintainers.length) ? pkg.maintainers[0].name : null)
     } catch (e) {
       if (e.response?.status !== 404) {
         this.logger.log(`[${plugin.name}] Failed to check registry.npmjs.org for updates: "${e.message}" - see https://homebridge.io/w/JJSz6 for help.`)

--- a/src/modules/plugins/types.d.ts
+++ b/src/modules/plugins/types.d.ts
@@ -3,6 +3,7 @@ export interface HomebridgePlugin {
   private: boolean
   displayName?: string
   description?: string
+  keywords?: string[]
   verifiedPlugin?: boolean
   verifiedPlusPlugin?: boolean
   icon?: string
@@ -123,8 +124,7 @@ export interface INpmSearchResultItem {
 }
 
 export interface INpmSearchResults {
-  total: number
-  results: INpmSearchResultItem[]
+  objects: INpmSearchResultItem[]
 }
 
 export interface IPackageJson {


### PR DESCRIPTION
## :recycle: Current situation

Search using `npms.io` appears to only search for plugins whose names match the search terms and does not include the keywords, compared to `registry.npmjs.org` which does a full text search.

## :bulb: Proposed solution

This code change restores the URL to `registry.npmjs.org` and filters the results for matches in the names and/or keywords. 

## :heavy_plus_sign: Additional Information

**Note:**

1.  The filter does not check the plugin `description` field for matches
2. The filter matches keywords against individual search terms
   a. A search for "dummy switch" will match against keywords "dummy" and "switch"
   b. A search for "dummy switch" will not match against keyword "dummy switch"
3. The filter does not match against partial keywords. A search item "dummy" will not match keyword "dummy switch"

Should 2b and 3 be matches?