### PR TITLE
Fix beta update check

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -750,7 +750,7 @@ export class PluginsService {
         '/var/packages/homebridge/target/app/lib/node_modules',
       ].includes(dirname(process.env.UIX_BASE_PATH))
       && pluginAction.name === this.configService.name
-      && pluginAction.version !== 'latest'
+      && !['latest', 'beta'].includes(pluginAction.version)
     ) {
       try {
         try {

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -750,7 +750,7 @@ export class PluginsService {
         '/var/packages/homebridge/target/app/lib/node_modules',
       ].includes(dirname(process.env.UIX_BASE_PATH))
       && pluginAction.name === this.configService.name
-      && !['latest', 'beta'].includes(pluginAction.version)
+      && !['latest', 'alpha', 'beta'].includes(pluginAction.version)
     ) {
       try {
         try {

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -763,7 +763,7 @@ export class PluginsService {
           return withoutV
         }
       } catch (e) {
-        this.logger.error(`Failed to check for bundled update as ${e.message}.`)
+        this.logger.error(`Failed to check for bundled update: ${e.message}.`)
         return ''
       }
     } else {


### PR DESCRIPTION
## :recycle: Current situation

This fixes the following error when updating beta versions:
"Failed to check for bundled update as Request failed with status code 404"

It's unclear if `alpha`, `next`, or `test` need to be inlcuded.

## :bulb: Proposed solution

Prevent 404 errors when looking for a `beta` release instead of a tagged release.

This also reverts the logging change in c81fdddaaa696b1b7ef829f5082b61747863fd45 to improve grammar.