### PR TITLE
Improve plugins Manage Version's select UI

### DIFF
--- a/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
+++ b/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
@@ -52,16 +52,17 @@
             <select class="custom-select w-100" style="font-size: 0.875rem" [(ngModel)]="versionSelect">
               @for (version of versions; track version) {
               <option [value]="version.version" [selected]="versionSelect == version.version">
-                v{{ version.version }}
-                @if (version.version == plugin.installedVersion) {
-                  ✓
-                }
+                v{{ version.version }} @if (version.version == plugin.installedVersion) { ✓ }
               </option>
               }
             </select>
           </div>
           @if (versionSelect) {
-          <button class="btn btn-primary m-0 ms-3" [disabled]="versionSelect === plugin.installedVersion" (click)="doInstall(versionSelect)">
+          <button
+            class="btn btn-primary m-0 ms-3"
+            [disabled]="versionSelect === plugin.installedVersion"
+            (click)="doInstall(versionSelect)"
+          >
             @if (versionSelect === plugin.installedVersion) {
             <i class="fas fa-fw fa-check-circle"></i>
             } @else {

--- a/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
+++ b/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
@@ -52,10 +52,9 @@
             <select class="custom-select w-100" style="font-size: 0.875rem" [(ngModel)]="versionSelect">
               @for (version of versions; track version) {
               <option [value]="version.version" [selected]="versionSelect == version.version">
-                {{ version.tag }}
                 v{{ version.version }}
                 @if (version.version == plugin.installedVersion) {
-                  <span> (✓)</span>
+                  ✓
                 }
               </option>
               }

--- a/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
+++ b/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
@@ -51,7 +51,13 @@
             <br />
             <select class="custom-select w-100" style="font-size: 0.875rem" [(ngModel)]="versionSelect">
               @for (version of versions; track version) {
-              <option [value]="version.version">v{{ version.version }}</option>
+              <option [value]="version.version" [selected]="versionSelect == version.version">
+                {{ version.tag }}
+                v{{ version.version }}
+                @if (version.version == plugin.installedVersion) {
+                  <span> (✓)</span>
+                }
+              </option>
               }
             </select>
           </div>

--- a/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
+++ b/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
@@ -61,13 +61,13 @@
               }
             </select>
           </div>
-          @if (versionSelect !== plugin.installedVersion) {
-          <button class="btn btn-primary m-0 ms-3" [disabled]="!versionSelect" (click)="doInstall(versionSelect)">
-            <i class="fas fa-fw fa-arrow-alt-circle-down"></i>
-          </button>
-          } @if (versionSelect && versionSelect === plugin.installedVersion) {
-          <button class="btn btn-primary m-0 ms-3" disabled>
+          @if (versionSelect) {
+          <button class="btn btn-primary m-0 ms-3" [disabled]="versionSelect === plugin.installedVersion" (click)="doInstall(versionSelect)">
+            @if (versionSelect === plugin.installedVersion) {
             <i class="fas fa-fw fa-check-circle"></i>
+            } @else {
+            <i class="fas fa-fw fa-arrow-alt-circle-down"></i>
+            }
           </button>
           }
         </li>

--- a/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
+++ b/ui/src/app/core/manage-plugins/manage-version/manage-version.component.html
@@ -14,7 +14,7 @@
     <div class="w-100 text-center primary-text">
       <i class="fa fa-fw fa-cog fa-spin" style="font-size: 75px"></i>
     </div>
-    } @if (!loading) {
+    } @else {
     <div class="w-100 text-center">
       @if (plugin.installedVersion) {
       <i class="fas fa-fw fa-code-compare primary-text mb-3" style="font-size: 75px"></i>
@@ -22,7 +22,7 @@
       <p class="mb-3">
         {{ 'plugins.status_installed' | translate }}: <span class="font-monospace">v{{ plugin.installedVersion }}</span>
       </p>
-      } @if (!plugin.installedVersion) {
+      } @else {
       <i class="far fa-fw fa-arrow-alt-circle-down primary-text mb-3" style="font-size: 75px"></i>
       <h6 class="mb-3">{{ 'plugins.manage.select_version' | translate }}</h6>
       }
@@ -38,7 +38,7 @@
           <button class="btn btn-primary m-0 ms-3" (click)="doInstall(version.version)">
             <i class="fas fa-fw fa-arrow-alt-circle-down"></i>
           </button>
-          } @if (plugin.installedVersion === version.version) {
+          } @else {
           <button class="btn btn-primary m-0 ms-3" disabled>
             <i class="fas fa-fw fa-check-circle"></i>
           </button>


### PR DESCRIPTION
## :recycle: Current situation

The plugin "Manage Version" window has a couple minor (extremely minor) issues.

This screenshot shows it immediately after opening with no subsequent interaction.

1. The install button next to the select element should be enabled, as the selected version is 1.0.8, which is newer than the currently installed version of 1.0.6. I realize that the prior row is the latest version, which is the intended option here.
2. To that point, the default selected version in the select element I selected is always going to be the same as one of the tagged versions (I think always latest), so it's kind of redundant here.

![Homebridge C647 - Safari - 2025-04-30 at 14 28 30@2x](https://github.com/user-attachments/assets/ee2945ed-db85-4a7d-b8ba-6866f93b3931)

## :bulb: Proposed solution

This PR proposes selecting the currently installed version by default in the select element, which makes the disabling of the install button make sense. It also adds a checkmark within the option element to indicate which is installed, which is nice when interacting with the control.

![Homebridge C647 - Safari - 2025-04-30 at 14 51 50@2x](https://github.com/user-attachments/assets/961a1256-cb5f-4c56-944f-1d41714916f0)
![Homebridge C647 - Safari - 2025-04-30 at 14 51 54@2x](https://github.com/user-attachments/assets/fa020fc3-c88f-42e6-b3fb-caef935a9da1)

## :gear: Release Notes

No breaking changes.

Select and highlight current version in the plugin Manage Versions window.

## :heavy_plus_sign: Additional Information

I also cleaned up some of the angular conditionals in this template. There were a lot of cases of `if (condition); if (!condition)` that could be replaced with `if (condition) else` (This is a code smell, as it's not clear from reading only the second conditional that it's mutually exclusive with the prior).

A couple notes as a first time contributor:

- `npm run lint` fails locally (and I can't rely on the PR since running requires maintainer kickoff).
   ```
   ❯ npm run lint

   > homebridge-config-ui-x@4.73.0 lint
   > eslint . --max-warnings=0


   Oops! Something went wrong! :(

   ESLint: 9.25.0

   Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/cameronlittle/Developer/homebridge-config-ui-x/node_modules/@antfu/eslint-config/dist/index.js from /Users/cameronlittle/Developer/homebridge-config-ui-x/eslint.config.js not supported.
   Instead change the require of index.js in /Users/cameronlittle/Developer/homebridge-config-ui-x/eslint.config.js to a dynamic import() which is available in all CommonJS modules.
       at TracingChannel.traceSync (node:diagnostics_channel:315:14)
       at Object.<anonymous> (/Users/cameronlittle/Developer/homebridge-config-ui-x/eslint.config.js:1:19)
    ```
- [formatOnSave is enabled in vscode](https://github.com/homebridge/homebridge-config-ui-x/blob/latest/.vscode/settings.json#L8) (great!) but the file I'm working on here isn't formatted already, which leads to a ton of mess in the PR without disabling or manually reverting changes. Ideally a big PR would go through formatting everything and requiring formatting in PR checks so I wouldn't have to worry about this.

### Testing

No tests added or changed (didn't see any existing test patterns for this detailed a UI concern). Manually tested locally.

### Reviewer Nudging

See inline comments.
