### PR TITLE
Update speaker tile status

### DIFF
--- a/ui/src/app/core/accessories/types/speaker/speaker.component.html
+++ b/ui/src/app/core/accessories/types/speaker/speaker.component.html
@@ -1,6 +1,6 @@
 <div
   class="accessory-box"
-  [ngClass]="{ 'switch-on': !service.values.Mute }"
+  [ngClass]="{ 'switch-on': (service.values.Active !== undefined) ? service.values.Active === 1 : !service.values.Mute }"
   appLongclick
   (longclick)="onLongClick()"
   (shortclick)="onClick()"
@@ -9,7 +9,9 @@
   <div class="d-flex flex-column h-100">
     <div [inlineSVG]="'/assets/hap-icons/speaker.svg'" [attr.aria-label]="'Speaker'" class="accessory-svg"></div>
     <div class="accessory-label mt-auto">{{ service.customName || service.serviceName }}</div>
-    @if (service.values.Mute) {
+    @if (service.values.Active !== undefined && service.values.Active === 0) {
+    <div class="accessory-label red-text" [innerText]="'accessories.control.inactive' | translate"></div>
+    } @if (service.values.Mute) {
     <div class="accessory-label red-text" [innerText]="'accessories.control.mute' | translate"></div>
     } @if (service.values.Volume !== undefined && !service.values.Mute) {
     <div class="accessory-label grey-text">{{ service.values.Volume }}%</div>


### PR DESCRIPTION
## :recycle: Current situation

The Speaker accessory tile shows the accessory as `On` when it's `Mute` property is false (audible) and as `Off` when it's `Mute` property is true, regardless of the `Active` property.

## :bulb: Proposed solution

If the Speaker accessory has the `Active` property, then the accessory tile shows the accessory as `On` when it's `Active` property is `active/1` and as `Off` when it's `Active` property is `inactive/0`.
