### PR TITLE
Fixed speaker tile and control modal

### DIFF
--- a/ui/src/app/core/accessories/types/speaker/speaker.component.html
+++ b/ui/src/app/core/accessories/types/speaker/speaker.component.html
@@ -11,11 +11,11 @@
     <div class="accessory-label mt-auto">{{ service.customName || service.serviceName }}</div>
     @if (service.values.Active !== undefined && service.values.Active === 0) {
     <div class="accessory-label red-text" [innerText]="'accessories.control.inactive' | translate"></div>
-    } @if (service.values.Mute) {
+    } @else if (service.values.Mute) {
     <div class="accessory-label red-text" [innerText]="'accessories.control.mute' | translate"></div>
-    } @if (service.values.Volume !== undefined && !service.values.Mute) {
+    } @else if (service.values.Volume !== undefined) {
     <div class="accessory-label grey-text">{{ service.values.Volume }}%</div>
-    } @if (service.values.Volume === undefined && !service.values.Mute) {
+    } @else {
     <div class="accessory-label grey-text">{{ 'accessories.control.not_mute' | translate }}</div>
     }
   </div>

--- a/ui/src/app/core/accessories/types/speaker/speaker.component.ts
+++ b/ui/src/app/core/accessories/types/speaker/speaker.component.ts
@@ -30,8 +30,7 @@ export class SpeakerComponent {
     const active = this.service.getCharacteristic('Active')
     if (active !== undefined) {
       active.setValue(this.service.values.Active === 0 ? 1 : 0)
-    }
-    else {
+    } else {
       this.service.getCharacteristic('Mute').setValue(!this.service.values.Mute)
     }
   }

--- a/ui/src/app/core/accessories/types/speaker/speaker.component.ts
+++ b/ui/src/app/core/accessories/types/speaker/speaker.component.ts
@@ -27,7 +27,13 @@ export class SpeakerComponent {
   constructor() {}
 
   onClick() {
-    this.service.getCharacteristic('Mute').setValue(!this.service.values.Mute)
+    const active = this.service.getCharacteristic('Active')
+    if (active !== undefined) {
+      active.setValue(this.service.values.Active === 0 ? 1 : 0)
+    }
+    else {
+      this.service.getCharacteristic('Mute').setValue(!this.service.values.Mute)
+    }
   }
 
   onLongClick() {

--- a/ui/src/app/core/accessories/types/speaker/speaker.component.ts
+++ b/ui/src/app/core/accessories/types/speaker/speaker.component.ts
@@ -36,7 +36,7 @@ export class SpeakerComponent {
   }
 
   onLongClick() {
-    if ('Volume' in this.service.values) {
+    if ('Volume' in this.service.values || 'Active' in this.service.values) {
       const ref = this.$modal.open(SpeakerManageComponent, {
         size: 'md',
       })

--- a/ui/src/app/core/accessories/types/speaker/speaker.manage.component.ts
+++ b/ui/src/app/core/accessories/types/speaker/speaker.manage.component.ts
@@ -45,7 +45,7 @@ export class SpeakerManageComponent implements OnInit {
 
     this.loadTargetVolume()
 
-    if (this.service.serviceCharacteristics.find(c => c.type === 'SetDirection')) {
+    if (this.service.serviceCharacteristics.find(c => c.type === 'Active')) {
       this.hasActive = true
     }
   }


### PR DESCRIPTION
## :gear: Release Notes

- Fixed tile status display logic
  - If `Active` property is defined and value is `INACTIVE/0`: display `Inactive`
  - Else if `Mute` property value is `true`: display `Mute`
  - Else if `Volume` property is defined: display `XX%`
  - Else: display `Active`
- Fixed tile click logic
  - If `Active` property is defined: display `Inactive/Active`
  - Else display `Audible/Mute`
- Fixed control modal logic
  - Search for `Active` property