### PR TITLE
Add support for Dark Mode switching with Custom Plugin UI's

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
@@ -136,6 +136,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
   loadUi() {
     this.iframe = this.customPluginUiElementTarget().nativeElement as HTMLIFrameElement
     this.iframe.src = `${environment.api.base + this.basePath
+      // eslint-disable-next-line style/indent
       }/index.html?origin=${encodeURIComponent(location.origin)}&v=${encodeURIComponent(this.plugin.installedVersion)}`
   }
 

--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
@@ -71,7 +71,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
   private schemaFormRecentlyRefreshed = false
   private schemaFormRefreshSubject = new Subject()
 
-  constructor() {}
+  constructor() { }
 
   ngOnInit(): void {
     this.io = this.$ws.connectToNamespace('plugins/settings-ui')
@@ -136,7 +136,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
   loadUi() {
     this.iframe = this.customPluginUiElementTarget().nativeElement as HTMLIFrameElement
     this.iframe.src = `${environment.api.base + this.basePath
-    }/index.html?origin=${encodeURIComponent(location.origin)}&v=${encodeURIComponent(this.plugin.installedVersion)}`
+      }/index.html?origin=${encodeURIComponent(location.origin)}&v=${encodeURIComponent(this.plugin.installedVersion)}`
   }
 
   handleMessage = (e: MessageEvent) => {
@@ -284,6 +284,7 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
 
     // Set body class
     event.source.postMessage({ action: 'body-class', class: currentTheme }, event.origin)
+    event.source.postMessage({ action: 'body-class', class: 'modal-content' }, event.origin)
     if (darkMode) {
       event.source.postMessage({ action: 'body-class', class: 'dark-mode' }, event.origin)
     }
@@ -308,9 +309,6 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
     const customStyles = `
       body {
         height: unset !important;
-        background-color: ${darkMode ? '#242424' : '#FFFFFF'} !important;
-        color: ${darkMode ? '#FFFFFF' : '#000000'};
-        padding: 5px !important;
       }
     `
     event.source.postMessage({ action: 'inline-style', style: customStyles }, event.origin)

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -169,11 +169,9 @@ export class SettingsService {
         const iframeDoc = iframe.contentDocument
         if (iframeDoc) {
           const iframeBody = iframeDoc.body
-          const iframeHtml = iframeDoc.documentElement
 
           iframeBody.classList.remove(`config-ui-x-${this.theme}`)
           iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`)
-
           if (this.actualLightingMode === 'dark') {
 
             iframeBody.classList.add(`config-ui-x-dark-mode-${this.theme}`)
@@ -182,7 +180,6 @@ export class SettingsService {
               iframeBody.classList.add('dark-mode')
             }
           } else {
-
             iframeBody.classList.add(`config-ui-x-${this.theme}`)
 
             if (iframeBody.classList.contains('dark-mode')) {
@@ -193,7 +190,7 @@ export class SettingsService {
           // Notify iframe Angular app
           iframe.contentWindow.postMessage(
             { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme },
-            window.location.origin
+            window.location.origin,
           )
         }
       } catch (e) {

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -143,46 +143,36 @@ export class SettingsService {
 
     // Grab the body element
     const bodySelector = window.document.querySelector('body')
-    console.log('Main <body> update start:', { element: bodySelector, classes: bodySelector.classList.toString() });
 
     // Remove all existing theme classes
     bodySelector.classList.remove(`config-ui-x-${this.theme}`)
     bodySelector.classList.remove(`config-ui-x-dark-mode-${this.theme}`)
-    console.log('Main <body> removed classes:', `config-ui-x-${this.theme}`, `config-ui-x-dark-mode-${this.theme}`);
 
     // Set the new theme
     this.theme = theme
-    console.log('Theme set:', { theme, actualLightingMode: this.actualLightingMode });
     if (this.actualLightingMode === 'dark') {
       bodySelector.classList.add(`config-ui-x-dark-mode-${this.theme}`)
       if (!bodySelector.classList.contains('dark-mode')) {
         bodySelector.classList.add('dark-mode')
       }
-      console.log('Main <body> added classes:', `config-ui-x-dark-mode-${this.theme}`, 'dark-mode')
     } else {
       bodySelector.classList.add(`config-ui-x-${this.theme}`)
       if (bodySelector.classList.contains('dark-mode')) {
         bodySelector.classList.remove('dark-mode')
       }
-      console.log('Main <body> added class:', `config-ui-x-${this.theme}`, 'Removed: dark-mode');
     }
-
-    console.log('Main <body> update end:', { classes: bodySelector.classList.toString() })
 
     // Update same-origin iframes
     const iframes = window.document.querySelectorAll('iframe');
-    console.log(`Found ${iframes.length} iframe(s)`);
     iframes.forEach((iframe, index) => {
       try {
         const iframeDoc = iframe.contentDocument;
         if (iframeDoc) {
           const iframeBody = iframeDoc.body;
           const iframeHtml = iframeDoc.documentElement;
-          console.log(`Iframe ${index} update start:`, { element: iframeBody, classes: iframeBody.classList.toString(), src: iframe.src });
 
           iframeBody.classList.remove(`config-ui-x-${this.theme}`);
           iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`);
-          console.log(`Iframe ${index} removed classes:`, `config-ui-x-${this.theme}`, `config-ui-x-dark-mode-${this.theme}`);
 
           if (this.actualLightingMode === 'dark') {
 
@@ -191,7 +181,6 @@ export class SettingsService {
             if (!iframeBody.classList.contains('dark-mode')) {
               iframeBody.classList.add('dark-mode');
             }
-            console.log(`Iframe ${index} added classes:`, `config-ui-x-dark-mode-${this.theme}`, 'dark-mode');
           } else {
 
             iframeBody.classList.add(`config-ui-x-${this.theme}`);
@@ -199,19 +188,13 @@ export class SettingsService {
             if (iframeBody.classList.contains('dark-mode')) {
               iframeBody.classList.remove('dark-mode');
             }
-            console.log(`Iframe ${index} added class:`, `config-ui-x-${this.theme}`, 'Removed: dark-mode');
           }
-
-          console.log(`Iframe ${index} update end:`, { classes: iframeBody.classList.toString() });
 
           // Notify iframe Angular app
           iframe.contentWindow.postMessage(
             { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme },
             window.location.origin
           );
-          console.log(`Iframe ${index} sent postMessage:`, { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme });
-        } else {
-          console.log(`Iframe ${index}: No access to document`, { src: iframe.src });
         }
       } catch (e) {
         console.log(`Iframe ${index}: Access denied (cross-origin?)`, { error: e, src: iframe.src });

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -173,7 +173,6 @@ export class SettingsService {
           iframeBody.classList.remove(`config-ui-x-${this.theme}`)
           iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`)
           if (this.actualLightingMode === 'dark') {
-
             iframeBody.classList.add(`config-ui-x-dark-mode-${this.theme}`)
 
             if (!iframeBody.classList.contains('dark-mode')) {

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -163,30 +163,30 @@ export class SettingsService {
     }
 
     // Update same-origin iframes
-    const iframes = window.document.querySelectorAll('iframe');
+    const iframes = window.document.querySelectorAll('iframe')
     iframes.forEach((iframe, index) => {
       try {
-        const iframeDoc = iframe.contentDocument;
+        const iframeDoc = iframe.contentDocument
         if (iframeDoc) {
-          const iframeBody = iframeDoc.body;
-          const iframeHtml = iframeDoc.documentElement;
+          const iframeBody = iframeDoc.body
+          const iframeHtml = iframeDoc.documentElement
 
-          iframeBody.classList.remove(`config-ui-x-${this.theme}`);
-          iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`);
+          iframeBody.classList.remove(`config-ui-x-${this.theme}`)
+          iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`)
 
           if (this.actualLightingMode === 'dark') {
 
-            iframeBody.classList.add(`config-ui-x-dark-mode-${this.theme}`);
+            iframeBody.classList.add(`config-ui-x-dark-mode-${this.theme}`)
 
             if (!iframeBody.classList.contains('dark-mode')) {
-              iframeBody.classList.add('dark-mode');
+              iframeBody.classList.add('dark-mode')
             }
           } else {
 
-            iframeBody.classList.add(`config-ui-x-${this.theme}`);
+            iframeBody.classList.add(`config-ui-x-${this.theme}`)
 
             if (iframeBody.classList.contains('dark-mode')) {
-              iframeBody.classList.remove('dark-mode');
+              iframeBody.classList.remove('dark-mode')
             }
           }
 
@@ -194,13 +194,14 @@ export class SettingsService {
           iframe.contentWindow.postMessage(
             { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme },
             window.location.origin
-          );
+          )
         }
       } catch (e) {
-        console.log(`Iframe ${index}: Access denied (cross-origin?)`, { error: e, src: iframe.src });
+        console.warn(`Iframe ${index}: Access denied (cross-origin?)`, { error: e, src: iframe.src })
       }
-    });
+    })
   }
+
   setMenuMode(value: 'default' | 'freeze') {
     this.menuMode = value
   }

--- a/ui/src/app/core/settings.service.ts
+++ b/ui/src/app/core/settings.service.ts
@@ -138,31 +138,86 @@ export class SettingsService {
 
       // Save the new property to the config file
       firstValueFrom(this.$api.put('/config-editor/ui', { key: 'theme', value: theme }))
-        .catch(error => console.error(error))
+        .catch(error => console.error('Error saving setTheme:', error))
     }
 
     // Grab the body element
     const bodySelector = window.document.querySelector('body')
+    console.log('Main <body> update start:', { element: bodySelector, classes: bodySelector.classList.toString() });
 
     // Remove all existing theme classes
     bodySelector.classList.remove(`config-ui-x-${this.theme}`)
     bodySelector.classList.remove(`config-ui-x-dark-mode-${this.theme}`)
+    console.log('Main <body> removed classes:', `config-ui-x-${this.theme}`, `config-ui-x-dark-mode-${this.theme}`);
 
     // Set the new theme
     this.theme = theme
+    console.log('Theme set:', { theme, actualLightingMode: this.actualLightingMode });
     if (this.actualLightingMode === 'dark') {
       bodySelector.classList.add(`config-ui-x-dark-mode-${this.theme}`)
       if (!bodySelector.classList.contains('dark-mode')) {
         bodySelector.classList.add('dark-mode')
       }
+      console.log('Main <body> added classes:', `config-ui-x-dark-mode-${this.theme}`, 'dark-mode')
     } else {
       bodySelector.classList.add(`config-ui-x-${this.theme}`)
       if (bodySelector.classList.contains('dark-mode')) {
         bodySelector.classList.remove('dark-mode')
       }
+      console.log('Main <body> added class:', `config-ui-x-${this.theme}`, 'Removed: dark-mode');
     }
-  }
 
+    console.log('Main <body> update end:', { classes: bodySelector.classList.toString() })
+
+    // Update same-origin iframes
+    const iframes = window.document.querySelectorAll('iframe');
+    console.log(`Found ${iframes.length} iframe(s)`);
+    iframes.forEach((iframe, index) => {
+      try {
+        const iframeDoc = iframe.contentDocument;
+        if (iframeDoc) {
+          const iframeBody = iframeDoc.body;
+          const iframeHtml = iframeDoc.documentElement;
+          console.log(`Iframe ${index} update start:`, { element: iframeBody, classes: iframeBody.classList.toString(), src: iframe.src });
+
+          iframeBody.classList.remove(`config-ui-x-${this.theme}`);
+          iframeBody.classList.remove(`config-ui-x-dark-mode-${this.theme}`);
+          console.log(`Iframe ${index} removed classes:`, `config-ui-x-${this.theme}`, `config-ui-x-dark-mode-${this.theme}`);
+
+          if (this.actualLightingMode === 'dark') {
+
+            iframeBody.classList.add(`config-ui-x-dark-mode-${this.theme}`);
+
+            if (!iframeBody.classList.contains('dark-mode')) {
+              iframeBody.classList.add('dark-mode');
+            }
+            console.log(`Iframe ${index} added classes:`, `config-ui-x-dark-mode-${this.theme}`, 'dark-mode');
+          } else {
+
+            iframeBody.classList.add(`config-ui-x-${this.theme}`);
+
+            if (iframeBody.classList.contains('dark-mode')) {
+              iframeBody.classList.remove('dark-mode');
+            }
+            console.log(`Iframe ${index} added class:`, `config-ui-x-${this.theme}`, 'Removed: dark-mode');
+          }
+
+          console.log(`Iframe ${index} update end:`, { classes: iframeBody.classList.toString() });
+
+          // Notify iframe Angular app
+          iframe.contentWindow.postMessage(
+            { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme },
+            window.location.origin
+          );
+          console.log(`Iframe ${index} sent postMessage:`, { type: 'theme-update', isDark: this.actualLightingMode === 'dark', theme });
+        } else {
+          console.log(`Iframe ${index}: No access to document`, { src: iframe.src });
+        }
+      } catch (e) {
+        console.log(`Iframe ${index}: Access denied (cross-origin?)`, { error: e, src: iframe.src });
+      }
+    });
+  }
   setMenuMode(value: 'default' | 'freeze') {
     this.menuMode = value
   }

--- a/ui/src/app/modules/plugins/plugin-card/plugin-card.component.ts
+++ b/ui/src/app/modules/plugins/plugin-card/plugin-card.component.ts
@@ -58,7 +58,7 @@ export class PluginCardComponent implements OnInit {
 
   private io: IoNamespace
 
-  constructor() {}
+  constructor() { }
 
   // eslint-disable-next-line accessor-pairs
   @Input() set childBridges(childBridges: any[]) {
@@ -79,7 +79,7 @@ export class PluginCardComponent implements OnInit {
 
     this.setChildBridges = childBridges
 
-    const homebridgeVersion = this.$settings.env.homebridgeVersion.split('.')[0]
+    const homebridgeVersion = this.$settings.env.homebridgeVersion?.split('.')[0]
     const hbEngines = this.plugin.engines?.homebridge?.split('||').map((x: string) => x.trim()) || []
     this.hb2Status = homebridgeVersion === '2' ? 'hide' : hbEngines.some((x: string) => (x.startsWith('^2') || x.startsWith('>=2'))) ? 'supported' : this.hb2Status
   }


### PR DESCRIPTION
Adds missing pieces for Dark Mode support in the custom plugin UI

1 - Removed background and colour hardcoding, and leveraged existing class modal-content instead.

2 - Added support for real time dark mode switching by leveraging existing switcher, and extends to the custom plugin iFrame

3 - Fixed a minor issue with homebridgeVersion missing blocking the Plugin page from loading.

In custom-plugin UI's to support real time switching of dark mode, the ui content needs to be wrapped in the class 'modal-body'

ie

```html
<div class="modal-body">
existing ui content
</div>
```