### PR TITLE
Fix search and result ordering

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -943,7 +943,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-        + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1,4 +1,4 @@
-/* eslint no-multi-spaces: ["error", { ignoreEOLComments: true }]*/
+/* eslint-disable no-multi-spaces */
 /* eslint-disable operator-linebreak */
 /* eslint-disable consistent-list-newline */
 

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -378,17 +378,17 @@ export class PluginsService {
     // Order each group by: Homebridge scoped, verified Plus, verified
     exactNameMatchPlugins = orderBy(
       exactNameMatchPlugins,
-      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin', 'lastUpdated'],
       ['desc', 'desc', 'desc'],
     )
     exactKeywordMatchPlugins = orderBy(
       exactKeywordMatchPlugins,
-      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin', 'lastUpdated'],
       ['desc', 'desc', 'desc'],
     )
     partialKeywordMatchPlugins = orderBy(
       partialKeywordMatchPlugins,
-      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin', 'lastUpdated'],
       ['desc', 'desc', 'desc'],
     )
 
@@ -943,7 +943,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1,5 +1,5 @@
-/* eslint-disable no-multi-spaces */
-/* eslint-disable operator-linebreak */
+/* eslint-disable style/no-multi-spaces */
+/* eslint-disable style/operator-linebreak */
 
 /* global NodeJS */
 import type { EventEmitter } from 'node:events'

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-multi-spaces */
 /* eslint-disable operator-linebreak */
-/* eslint-disable consistent-list-newline */
 
 /* global NodeJS */
 import type { EventEmitter } from 'node:events'

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -343,14 +343,15 @@ export class PluginsService {
     result.forEach((plugin) => {
       const pluginName = plugin.name.toLowerCase()
 
-      // Name contains all search terms
+      // Name contains all the search terms
       const isExactNameMatch =
         searchTerms.every(term => pluginName.includes(term))
       if (isExactNameMatch) {
         exactNameMatchPlugins.push(plugin)
+        return
       }
 
-      // Keywords contain all search terms
+      // Keywords contain all the search terms
       const pluginKeywords = plugin.keywords.map(keyword => keyword.toLowerCase())
       const isExactKeywordMatch =
         searchTerms.every(term => pluginKeywords.includes(term))
@@ -359,7 +360,7 @@ export class PluginsService {
         return
       }
 
-      // Name, keywords or description contain all some search terms
+      // Name, keywords or description contain some of the search terms
       const pluginDescription = plugin.description.toLowerCase()
       const isPartialKeywordMatch =
         searchTerms.some(term => pluginName.includes(term)) ||

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -943,7 +943,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1,3 +1,7 @@
+/* eslint no-multi-spaces: ["error", { ignoreEOLComments: true }]*/
+/* eslint-disable operator-linebreak */
+/* eslint-disable consistent-list-newline */
+
 /* global NodeJS */
 import type { EventEmitter } from 'node:events'
 
@@ -373,17 +377,20 @@ export class PluginsService {
     })
 
     // Order each group by: Homebridge scoped, verified Plus, verified
-    exactNameMatchPlugins = orderBy(exactNameMatchPlugins,
+    exactNameMatchPlugins = orderBy(
+      exactNameMatchPlugins,
       ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
-      ['desc', 'desc', 'desc']
+      ['desc', 'desc', 'desc'],
     )
-    exactKeywordMatchPlugins = orderBy(exactKeywordMatchPlugins,
+    exactKeywordMatchPlugins = orderBy(
+      exactKeywordMatchPlugins,
       ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
-      ['desc', 'desc', 'desc']
+      ['desc', 'desc', 'desc'],
     )
-    partialKeywordMatchPlugins = orderBy(partialKeywordMatchPlugins,
+    partialKeywordMatchPlugins = orderBy(
+      partialKeywordMatchPlugins,
       ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
-      ['desc', 'desc', 'desc']
+      ['desc', 'desc', 'desc'],
     )
 
     // Assemble set in order of match

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -257,7 +257,14 @@ export class PluginsService {
       await this.getInstalledPlugins()
     }
 
-    query = query.trim().toLowerCase()
+    const queryTerms: string[] = query
+      .split(/\s+/)                           // split into words
+      .filter(term => term.length > 0)        // remove empty strings
+      .filter(term => term !== 'homebridge')  // remove noisy term
+      .filter(term => term !== 'plugin')      // remove noisy term
+
+    // Did we strip too much?
+    query = (queryTerms.length > 0) ? queryTerms.join(' ').toLowerCase() : 'homebridge'
 
     if ((query.startsWith('homebridge-') || this.isScopedPlugin(query)) && !this.hiddenPlugins.includes(query)) {
       // Change the query to the scoped version if it exists, and the 'old' version is not installed
@@ -328,30 +335,58 @@ export class PluginsService {
       .filter(term => term.length > 0) // remove empty strings
 
     // Separate lists for exact matches and partial matches
-    const exactMatchPlugins: HomebridgePlugin[] = []
-    const partialMatchPlugins: HomebridgePlugin[] = []
+    let exactNameMatchPlugins: HomebridgePlugin[] = []
+    let exactKeywordMatchPlugins: HomebridgePlugin[] = []
+    let partialKeywordMatchPlugins: HomebridgePlugin[] = []
 
     // Filter matching plugins
     result.forEach((plugin) => {
+      const pluginName = plugin.name.toLowerCase()
+
+      // Name contains all search terms
+      const isExactNameMatch =
+        searchTerms.every(term => pluginName.includes(term))
+      if (isExactNameMatch) {
+        exactNameMatchPlugins.push(plugin)
+      }
+
+      // Keywords contain all search terms
       const pluginKeywords = plugin.keywords.map(keyword => keyword.toLowerCase())
-      const isExactMatch = pluginKeywords.includes(searchTerm)
-      if (isExactMatch) {
-        exactMatchPlugins.push(plugin)
+      const isExactKeywordMatch =
+        searchTerms.every(term => pluginKeywords.includes(term))
+      if (isExactKeywordMatch) {
+        exactKeywordMatchPlugins.push(plugin)
         return
       }
 
-      const pluginName = plugin.name.toLowerCase()
+      // Name, keywords or description contain all some search terms
       const pluginDescription = plugin.description.toLowerCase()
-      const isPartialMatch = searchTerms.some(term => pluginName.includes(term))
-        || searchTerms.some(term => pluginKeywords.some(keyword => keyword.includes(term)))
-        || searchTerms.some(term => pluginDescription.includes(term))
+      const isPartialKeywordMatch =
+        searchTerms.some(term => pluginName.includes(term)) ||
+        searchTerms.some(term => pluginKeywords.some(keyword => keyword.includes(term))) ||
+        searchTerms.some(term => pluginDescription.includes(term))
 
-      if (isPartialMatch) {
-        partialMatchPlugins.push(plugin)
+      if (isPartialKeywordMatch) {
+        partialKeywordMatchPlugins.push(plugin)
       }
     })
 
-    return orderBy([...exactMatchPlugins, ...partialMatchPlugins], ['verifiedPlusPlugin', 'verifiedPlugin'], ['desc', 'desc'])
+    // Order each group by: Homebridge scoped, verified Plus, verified
+    exactNameMatchPlugins = orderBy(exactNameMatchPlugins,
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['desc', 'desc', 'desc']
+    )
+    exactKeywordMatchPlugins = orderBy(exactKeywordMatchPlugins,
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['desc', 'desc', 'desc']
+    )
+    partialKeywordMatchPlugins = orderBy(partialKeywordMatchPlugins,
+      ['isHbScoped', 'verifiedPlusPlugin', 'verifiedPlugin'],
+      ['desc', 'desc', 'desc']
+    )
+
+    // Assemble set in order of match
+    return [...exactNameMatchPlugins, ...exactKeywordMatchPlugins, ...partialKeywordMatchPlugins]
       .slice(0, 30)
       .map(plugin => this.fixDisplayName(plugin))
   }
@@ -901,7 +936,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -944,7 +944,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+        + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))


### PR DESCRIPTION
## :recycle: Current situation

The current search has two problems:

1. The keywords "homebridge" and "plugin" create a lot of noise. Every plugin has those two keywords, so in a search for "homebridge plugin unicorns", the valuable search term "unicorns" occurs as the third term
2. The ordering of the search results splits the exact matches from the exact matches, before joining them and reordering them, making the initial split useless

## :bulb: Proposed solution

1. Fix the search by removing the "homebridge" and "plugin" keywords from the search query. Add back "homebridge" if the query ends up empty because the user searched for any combinations of those two keywords
2. Split the search results into three groups:
  a. Exact name match: the plugin name contains all of the search terms
  b. Exact keywords match: the keywords contain all of the search terms
  c. Partial match: the name, keywords, or descriptions some of the search terms
3. Order each group individually by scoped (purple shield), verified plus (?), verified (green shield), not verified (orange shield, and last updated date (to get latest updated plugins first)
4. Join the three groups and take the top X
