### PR TITLE
Fix alignment of Plugin Updates in Horizontal Mode

### DIFF
--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -3,15 +3,11 @@
     {{ 'status.services.updates' | translate }}
   </div>
   <div
-    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-center"
-  >
+    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-center">
     @if (serverInfo && serverInfo.homebridgeRunningInDocker) {
     <div class="hb-status-item d-flex flex-column mb-1" style="min-width: max(25%, 200px)">
-      <div
-        class="d-flex ps-3 py-1 align-items-center cursor-pointer"
-        (click)="toggleDockerExpand()"
-        style="cursor: pointer"
-      >
+      <div class="d-flex ps-3 py-1 align-items-center cursor-pointer" (click)="toggleDockerExpand()"
+        style="cursor: pointer">
         <div class="mb-0 d-flex align-items-center">
           @if (!dockerStatusDone) {
           <i class="fas fa-fw fa-lg fa-cog fa-spin primary-text"></i>
@@ -39,6 +35,7 @@
       </div>
       @if (dockerExpanded) {
       <div class="ps-5 pe-3 d-flex flex-wrap">
+        <!-- Homebridge -->
         <div class="hb-status-item d-flex flex-row py-1" style="min-width: 200px; flex: 1 0 auto">
           <div class="d-flex ps-3 py-1">
             <div class="mb-0 d-flex align-items-center">
@@ -52,28 +49,13 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgePkg.installedVersion) {
-              <a
-                href="javascript:void(0)"
-                (click)="installAlternateVersion(homebridgePkg)"
-                class="card-link card-link-title"
-                >Homebridge</a
-              >
+              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
+                class="card-link card-link-title">Homebridge</a>
               @if (!isRunningHbV2) {
-              <a
-                href="javascript:void(0)"
-                class="ms-1"
-                (click)="readyForV2Modal()"
-                ngbTooltip="Homebridge v2 Readiness"
-                container="body"
-                openDelay="150"
-                triggers="hover"
-                placement="top"
-                aria-label="Homebridge v2 Readiness"
-              >
-                <i
-                  class="fas fa-fw fa-info-circle"
-                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
-                ></i>
+              <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
+                container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
+                <i class="fas fa-fw fa-info-circle"
+                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
               </a>
               } } @if (!homebridgePkg.installedVersion) {
               <span>Homebridge</span>
@@ -91,6 +73,7 @@
             </div>
           </div>
         </div>
+        <!-- Homebridge UI -->
         <div class="hb-status-item d-flex flex-row py-1" style="min-width: 200px; flex: 1 0 auto">
           <div class="d-flex ps-3 py-1">
             <div class="mb-0 d-flex align-items-center">
@@ -104,12 +87,8 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgeUiPkg.installedVersion) {
-              <a
-                href="javascript:void(0)"
-                (click)="installAlternateVersion(homebridgeUiPkg)"
-                class="card-link card-link-title"
-                >Homebridge UI</a
-              >
+              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
+                class="card-link card-link-title">Homebridge UI</a>
               } @if (!homebridgeUiPkg.installedVersion) {
               <span>Homebridge UI</span>
               }
@@ -126,6 +105,7 @@
             </div>
           </div>
         </div>
+        <!-- Node.js -->
         <div class="hb-status-item d-flex flex-row py-1" style="min-width: 200px; flex: 1 0 auto">
           <div class="d-flex ps-3 py-1">
             <div class="mb-0 d-flex align-items-center">
@@ -147,10 +127,9 @@
               @if (!nodejsStatusDone) {
               <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
               } @if (nodejsStatusDone) {
-              <span class="grey-text small"
-                >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
-                nodejsInfo.npmVersion }} }</span
-              >
+              <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion &&
+                nodejsInfo.npmVersion) { &middot; {{
+                nodejsInfo.npmVersion }} }</span>
               @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
               <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
                 {{'plugins.button_update' | translate }}
@@ -167,6 +146,7 @@
       }
     </div>
     } @if (serverInfo && !serverInfo.homebridgeRunningInDocker) {
+    <!-- Homebridge -->
     <div class="hb-status-item d-flex flex-row mb-1" style="min-width: max(25%, 225px)">
       <div class="d-flex ps-3 py-1">
         <div class="mb-0 d-flex align-items-center">
@@ -180,28 +160,13 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgePkg.installedVersion) {
-          <a
-            href="javascript:void(0)"
-            (click)="installAlternateVersion(homebridgePkg)"
-            class="card-link card-link-title"
-            >Homebridge</a
-          >
+          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
+            class="card-link card-link-title">Homebridge</a>
           @if (isHbV2Loaded && !isRunningHbV2) {
-          <a
-            href="javascript:void(0)"
-            class="ms-1"
-            (click)="readyForV2Modal()"
-            ngbTooltip="Homebridge v2 Readiness"
-            container="body"
-            openDelay="150"
-            triggers="hover"
-            placement="top"
-            aria-label="Homebridge v2 Readiness"
-          >
-            <i
-              class="fas fa-fw fa-info-circle"
-              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
-            ></i>
+          <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
+            container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
+            <i class="fas fa-fw fa-info-circle"
+              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
           </a>
           } } @if (!homebridgePkg.installedVersion) {
           <span>Homebridge</span>
@@ -218,6 +183,7 @@
         </div>
       </div>
     </div>
+    <!-- Homebridge UI -->
     <div class="hb-status-item d-flex flex-row mb-1" style="min-width: max(25%, 225px)">
       <div class="d-flex ps-3 py-1">
         <div class="mb-0 d-flex align-items-center">
@@ -231,12 +197,8 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgeUiPkg.installedVersion) {
-          <a
-            href="javascript:void(0)"
-            (click)="installAlternateVersion(homebridgeUiPkg)"
-            class="card-link card-link-title"
-            >Homebridge UI</a
-          >
+          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
+            class="card-link card-link-title">Homebridge UI</a>
           } @if (!homebridgeUiPkg.installedVersion) {
           <span>Homebridge UI</span>
           }
@@ -254,6 +216,7 @@
       </div>
     </div>
     }
+    <!-- Plugins -->
     <div class="hb-status-item d-flex flex-row mb-1" style="min-width: max(25%, 225px)">
       <div class="d-flex ps-3 py-1">
         <div class="mb-0 d-flex align-items-center">
@@ -281,6 +244,7 @@
       </div>
     </div>
     @if (serverInfo && !serverInfo.homebridgeRunningInDocker) {
+    <!-- Node.js -->
     <div class="hb-status-item d-flex flex-row mb-1" style="min-width: max(25%, 225px)">
       <div class="d-flex ps-3 py-1">
         <div class="mb-0 d-flex align-items-center">
@@ -302,10 +266,9 @@
           @if (!nodejsStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (nodejsStatusDone) {
-          <span class="grey-text small"
-            >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
-            nodejsInfo.npmVersion }} }</span
-          >
+          <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion)
+            { &middot; {{
+            nodejsInfo.npmVersion }} }</span>
           @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
             {{'plugins.button_update' | translate }}

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -3,11 +3,15 @@
     {{ 'status.services.updates' | translate }}
   </div>
   <div
-    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start">
+    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start"
+  >
     @if (serverInfo && serverInfo.homebridgeRunningInDocker) {
     <div class="hb-status-item d-flex flex-column mb-1" style="min-width: max(25%, 200px)">
-      <div class="d-flex ps-3 py-1 align-items-center cursor-pointer" (click)="toggleDockerExpand()"
-        style="cursor: pointer">
+      <div
+        class="d-flex ps-3 py-1 align-items-center cursor-pointer"
+        (click)="toggleDockerExpand()"
+        style="cursor: pointer"
+      >
         <div class="mb-0 d-flex align-items-center">
           @if (!dockerStatusDone) {
           <i class="fas fa-fw fa-lg fa-cog fa-spin primary-text"></i>
@@ -49,13 +53,28 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgePkg.installedVersion) {
-              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
-                class="card-link card-link-title">Homebridge</a>
+              <a
+                href="javascript:void(0)"
+                (click)="installAlternateVersion(homebridgePkg)"
+                class="card-link card-link-title"
+                >Homebridge</a
+              >
               @if (!isRunningHbV2) {
-              <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
-                container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
-                <i class="fas fa-fw fa-info-circle"
-                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
+              <a
+                href="javascript:void(0)"
+                class="ms-1"
+                (click)="readyForV2Modal()"
+                ngbTooltip="Homebridge v2 Readiness"
+                container="body"
+                openDelay="150"
+                triggers="hover"
+                placement="top"
+                aria-label="Homebridge v2 Readiness"
+              >
+                <i
+                  class="fas fa-fw fa-info-circle"
+                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
+                ></i>
               </a>
               } } @if (!homebridgePkg.installedVersion) {
               <span>Homebridge</span>
@@ -87,8 +106,12 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgeUiPkg.installedVersion) {
-              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
-                class="card-link card-link-title">Homebridge UI</a>
+              <a
+                href="javascript:void(0)"
+                (click)="installAlternateVersion(homebridgeUiPkg)"
+                class="card-link card-link-title"
+                >Homebridge UI</a
+              >
               } @if (!homebridgeUiPkg.installedVersion) {
               <span>Homebridge UI</span>
               }
@@ -127,9 +150,10 @@
               @if (!nodejsStatusDone) {
               <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
               } @if (nodejsStatusDone) {
-              <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion &&
-                nodejsInfo.npmVersion) { &middot; {{
-                nodejsInfo.npmVersion }} }</span>
+              <span class="grey-text small"
+                >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
+                nodejsInfo.npmVersion }} }</span
+              >
               @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
               <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
                 {{'plugins.button_update' | translate }}
@@ -160,13 +184,28 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgePkg.installedVersion) {
-          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
-            class="card-link card-link-title">Homebridge</a>
+          <a
+            href="javascript:void(0)"
+            (click)="installAlternateVersion(homebridgePkg)"
+            class="card-link card-link-title"
+            >Homebridge</a
+          >
           @if (isHbV2Loaded && !isRunningHbV2) {
-          <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
-            container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
-            <i class="fas fa-fw fa-info-circle"
-              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
+          <a
+            href="javascript:void(0)"
+            class="ms-1"
+            (click)="readyForV2Modal()"
+            ngbTooltip="Homebridge v2 Readiness"
+            container="body"
+            openDelay="150"
+            triggers="hover"
+            placement="top"
+            aria-label="Homebridge v2 Readiness"
+          >
+            <i
+              class="fas fa-fw fa-info-circle"
+              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
+            ></i>
           </a>
           } } @if (!homebridgePkg.installedVersion) {
           <span>Homebridge</span>
@@ -197,8 +236,12 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgeUiPkg.installedVersion) {
-          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
-            class="card-link card-link-title">Homebridge UI</a>
+          <a
+            href="javascript:void(0)"
+            (click)="installAlternateVersion(homebridgeUiPkg)"
+            class="card-link card-link-title"
+            >Homebridge UI</a
+          >
           } @if (!homebridgeUiPkg.installedVersion) {
           <span>Homebridge UI</span>
           }
@@ -266,9 +309,10 @@
           @if (!nodejsStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (nodejsStatusDone) {
-          <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion)
-            { &middot; {{
-            nodejsInfo.npmVersion }} }</span>
+          <span class="grey-text small"
+            >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
+            nodejsInfo.npmVersion }} }</span
+          >
           @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
             {{'plugins.button_update' | translate }}

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -3,7 +3,7 @@
     {{ 'status.services.updates' | translate }}
   </div>
   <div
-    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-center">
+    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start">
     @if (serverInfo && serverInfo.homebridgeRunningInDocker) {
     <div class="hb-status-item d-flex flex-column mb-1" style="min-width: max(25%, 200px)">
       <div class="d-flex ps-3 py-1 align-items-center cursor-pointer" (click)="toggleDockerExpand()"


### PR DESCRIPTION
Change was to put back align-items-start

#2478

To fake running in Docker, add these environment variables 

```bash
declare -x DOCKER_HOMEBRIDGE_VERSION="2025-06-04"
declare -x HOMEBRIDGE_CONFIG_UI="1"
```