### PR TITLE
Display apt pkg version

### DIFF
--- a/src/modules/status/status.service.ts
+++ b/src/modules/status/status.service.ts
@@ -617,6 +617,7 @@ export class StatusService {
    */
   public async getDockerDetails() {
     const currentVersion = process.env.DOCKER_HOMEBRIDGE_VERSION
+    const aptPkgVersion = process.env.HOMEBRIDGE_APT_PKG_VERSION
     let latestVersion: string | null = null
     let latestReleaseBody = ''
     let updateAvailable = false
@@ -679,6 +680,7 @@ export class StatusService {
       latestVersion,
       latestReleaseBody,
       updateAvailable,
+      aptPkgVersion,
     }
   }
 

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -3,15 +3,11 @@
     {{ 'status.services.updates' | translate }}
   </div>
   <div
-    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start"
-  >
+    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start">
     @if (serverInfo && serverInfo.homebridgeRunningInDocker) {
     <div class="hb-status-item d-flex flex-column mb-1" style="min-width: max(25%, 200px)">
-      <div
-        class="d-flex ps-3 py-1 align-items-center cursor-pointer"
-        (click)="toggleDockerExpand()"
-        style="cursor: pointer"
-      >
+      <div class="d-flex ps-3 py-1 align-items-center cursor-pointer" (click)="toggleDockerExpand()"
+        style="cursor: pointer">
         <div class="mb-0 d-flex align-items-center">
           @if (!dockerStatusDone) {
           <i class="fas fa-fw fa-lg fa-cog fa-spin primary-text"></i>
@@ -28,7 +24,7 @@
           @if (!dockerStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (dockerStatusDone) {
-          <span class="grey-text small">{{ dockerInfo.currentVersion }}</span>
+          <span class="grey-text small">{{ dockerInfo.currentVersion }} (v{{ dockerInfo.aptPkgVersion }})</span>
 
           @if (dockerInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="dockerUpdateModal()" class="primary-text small">
@@ -53,28 +49,13 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgePkg.installedVersion) {
-              <a
-                href="javascript:void(0)"
-                (click)="installAlternateVersion(homebridgePkg)"
-                class="card-link card-link-title"
-                >Homebridge</a
-              >
+              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
+                class="card-link card-link-title">Homebridge</a>
               @if (!isRunningHbV2) {
-              <a
-                href="javascript:void(0)"
-                class="ms-1"
-                (click)="readyForV2Modal()"
-                ngbTooltip="Homebridge v2 Readiness"
-                container="body"
-                openDelay="150"
-                triggers="hover"
-                placement="top"
-                aria-label="Homebridge v2 Readiness"
-              >
-                <i
-                  class="fas fa-fw fa-info-circle"
-                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
-                ></i>
+              <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
+                container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
+                <i class="fas fa-fw fa-info-circle"
+                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
               </a>
               } } @if (!homebridgePkg.installedVersion) {
               <span>Homebridge</span>
@@ -106,12 +87,8 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgeUiPkg.installedVersion) {
-              <a
-                href="javascript:void(0)"
-                (click)="installAlternateVersion(homebridgeUiPkg)"
-                class="card-link card-link-title"
-                >Homebridge UI</a
-              >
+              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
+                class="card-link card-link-title">Homebridge UI</a>
               } @if (!homebridgeUiPkg.installedVersion) {
               <span>Homebridge UI</span>
               }
@@ -150,10 +127,9 @@
               @if (!nodejsStatusDone) {
               <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
               } @if (nodejsStatusDone) {
-              <span class="grey-text small"
-                >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
-                nodejsInfo.npmVersion }} }</span
-              >
+              <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion &&
+                nodejsInfo.npmVersion) { &middot; {{
+                nodejsInfo.npmVersion }} }</span>
               @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
               <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
                 {{'plugins.button_update' | translate }}
@@ -184,28 +160,13 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgePkg.installedVersion) {
-          <a
-            href="javascript:void(0)"
-            (click)="installAlternateVersion(homebridgePkg)"
-            class="card-link card-link-title"
-            >Homebridge</a
-          >
+          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
+            class="card-link card-link-title">Homebridge</a>
           @if (isHbV2Loaded && !isRunningHbV2) {
-          <a
-            href="javascript:void(0)"
-            class="ms-1"
-            (click)="readyForV2Modal()"
-            ngbTooltip="Homebridge v2 Readiness"
-            container="body"
-            openDelay="150"
-            triggers="hover"
-            placement="top"
-            aria-label="Homebridge v2 Readiness"
-          >
-            <i
-              class="fas fa-fw fa-info-circle"
-              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
-            ></i>
+          <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
+            container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
+            <i class="fas fa-fw fa-info-circle"
+              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
           </a>
           } } @if (!homebridgePkg.installedVersion) {
           <span>Homebridge</span>
@@ -236,12 +197,8 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgeUiPkg.installedVersion) {
-          <a
-            href="javascript:void(0)"
-            (click)="installAlternateVersion(homebridgeUiPkg)"
-            class="card-link card-link-title"
-            >Homebridge UI</a
-          >
+          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
+            class="card-link card-link-title">Homebridge UI</a>
           } @if (!homebridgeUiPkg.installedVersion) {
           <span>Homebridge UI</span>
           }
@@ -309,10 +266,9 @@
           @if (!nodejsStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (nodejsStatusDone) {
-          <span class="grey-text small"
-            >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
-            nodejsInfo.npmVersion }} }</span
-          >
+          <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion)
+            { &middot; {{
+            nodejsInfo.npmVersion }} }</span>
           @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
             {{'plugins.button_update' | translate }}

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -28,7 +28,7 @@
           @if (!dockerStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (dockerStatusDone) {
-          <span class="grey-text small">{{ dockerInfo.currentVersion }}</span>
+          <span class="grey-text small">{{ dockerInfo.currentVersion }} (v{{ dockerInfo.aptPkgVersion }})</span>
 
           @if (dockerInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="dockerUpdateModal()" class="primary-text small">

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.html
@@ -3,11 +3,15 @@
     {{ 'status.services.updates' | translate }}
   </div>
   <div
-    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start">
+    class="d-flex flex-wrap w-100 mt-1 justify-content-start gridster-item-content overflow-auto no-scrollbars align-items-start"
+  >
     @if (serverInfo && serverInfo.homebridgeRunningInDocker) {
     <div class="hb-status-item d-flex flex-column mb-1" style="min-width: max(25%, 200px)">
-      <div class="d-flex ps-3 py-1 align-items-center cursor-pointer" (click)="toggleDockerExpand()"
-        style="cursor: pointer">
+      <div
+        class="d-flex ps-3 py-1 align-items-center cursor-pointer"
+        (click)="toggleDockerExpand()"
+        style="cursor: pointer"
+      >
         <div class="mb-0 d-flex align-items-center">
           @if (!dockerStatusDone) {
           <i class="fas fa-fw fa-lg fa-cog fa-spin primary-text"></i>
@@ -24,7 +28,7 @@
           @if (!dockerStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (dockerStatusDone) {
-          <span class="grey-text small">{{ dockerInfo.currentVersion }} (v{{ dockerInfo.aptPkgVersion }})</span>
+          <span class="grey-text small">{{ dockerInfo.currentVersion }}</span>
 
           @if (dockerInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="dockerUpdateModal()" class="primary-text small">
@@ -49,13 +53,28 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgePkg.installedVersion) {
-              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
-                class="card-link card-link-title">Homebridge</a>
+              <a
+                href="javascript:void(0)"
+                (click)="installAlternateVersion(homebridgePkg)"
+                class="card-link card-link-title"
+                >Homebridge</a
+              >
               @if (!isRunningHbV2) {
-              <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
-                container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
-                <i class="fas fa-fw fa-info-circle"
-                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
+              <a
+                href="javascript:void(0)"
+                class="ms-1"
+                (click)="readyForV2Modal()"
+                ngbTooltip="Homebridge v2 Readiness"
+                container="body"
+                openDelay="150"
+                triggers="hover"
+                placement="top"
+                aria-label="Homebridge v2 Readiness"
+              >
+                <i
+                  class="fas fa-fw fa-info-circle"
+                  [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
+                ></i>
               </a>
               } } @if (!homebridgePkg.installedVersion) {
               <span>Homebridge</span>
@@ -87,8 +106,12 @@
             </div>
             <div class="align-self-center px-3">
               @if (homebridgeUiPkg.installedVersion) {
-              <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
-                class="card-link card-link-title">Homebridge UI</a>
+              <a
+                href="javascript:void(0)"
+                (click)="installAlternateVersion(homebridgeUiPkg)"
+                class="card-link card-link-title"
+                >Homebridge UI</a
+              >
               } @if (!homebridgeUiPkg.installedVersion) {
               <span>Homebridge UI</span>
               }
@@ -127,9 +150,10 @@
               @if (!nodejsStatusDone) {
               <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
               } @if (nodejsStatusDone) {
-              <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion &&
-                nodejsInfo.npmVersion) { &middot; {{
-                nodejsInfo.npmVersion }} }</span>
+              <span class="grey-text small"
+                >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
+                nodejsInfo.npmVersion }} }</span
+              >
               @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
               <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
                 {{'plugins.button_update' | translate }}
@@ -160,13 +184,28 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgePkg.installedVersion) {
-          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgePkg)"
-            class="card-link card-link-title">Homebridge</a>
+          <a
+            href="javascript:void(0)"
+            (click)="installAlternateVersion(homebridgePkg)"
+            class="card-link card-link-title"
+            >Homebridge</a
+          >
           @if (isHbV2Loaded && !isRunningHbV2) {
-          <a href="javascript:void(0)" class="ms-1" (click)="readyForV2Modal()" ngbTooltip="Homebridge v2 Readiness"
-            container="body" openDelay="150" triggers="hover" placement="top" aria-label="Homebridge v2 Readiness">
-            <i class="fas fa-fw fa-info-circle"
-              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"></i>
+          <a
+            href="javascript:void(0)"
+            class="ms-1"
+            (click)="readyForV2Modal()"
+            ngbTooltip="Homebridge v2 Readiness"
+            container="body"
+            openDelay="150"
+            triggers="hover"
+            placement="top"
+            aria-label="Homebridge v2 Readiness"
+          >
+            <i
+              class="fas fa-fw fa-info-circle"
+              [ngClass]="{ 'green-text': isHbV2Ready, 'orange-text': !isHbV2Ready }"
+            ></i>
           </a>
           } } @if (!homebridgePkg.installedVersion) {
           <span>Homebridge</span>
@@ -197,8 +236,12 @@
         </div>
         <div class="align-self-center px-3">
           @if (homebridgeUiPkg.installedVersion) {
-          <a href="javascript:void(0)" (click)="installAlternateVersion(homebridgeUiPkg)"
-            class="card-link card-link-title">Homebridge UI</a>
+          <a
+            href="javascript:void(0)"
+            (click)="installAlternateVersion(homebridgeUiPkg)"
+            class="card-link card-link-title"
+            >Homebridge UI</a
+          >
           } @if (!homebridgeUiPkg.installedVersion) {
           <span>Homebridge UI</span>
           }
@@ -266,9 +309,10 @@
           @if (!nodejsStatusDone) {
           <span class="grey-text small">{{ 'status.homebridge.checking' | translate }}</span>
           } @if (nodejsStatusDone) {
-          <span class="grey-text small">{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion)
-            { &middot; {{
-            nodejsInfo.npmVersion }} }</span>
+          <span class="grey-text small"
+            >{{ serverInfo.nodeVersion }}@if (widget.showNpmVersion && nodejsInfo.npmVersion) { &middot; {{
+            nodejsInfo.npmVersion }} }</span
+          >
           @if (!widget.hideNodeInfo) { @if (nodejsInfo.updateAvailable) { &middot;
           <a href="javascript:void(0)" (click)="nodeUpdateModal()" class="primary-text small">
             {{'plugins.button_update' | translate }}

--- a/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.ts
+++ b/ui/src/app/modules/status/widgets/update-info-widget/update-info-widget.component.ts
@@ -61,6 +61,7 @@ export class UpdateInfoWidgetComponent implements OnInit {
     latestVersion: null,
     latestReleaseBody: '',
     updateAvailable: false,
+    aptPkgVersion: undefined,
   }
 
   public dockerStatusDone = false as boolean


### PR DESCRIPTION
## :recycle: Current situation

Homebridge UI shows the Docker version in the Update Information widget, but there is no direct connection to the Homebridge Linux apt pkg version which it wraps.

## :bulb: Proposed solution

Display the Homebridge Linux apt pkg version next to the Docker version in the Update Information widget.

## :heavy_plus_sign: Additional Information

This PR is a proposed code update for feature request [Display Homebridge Linux release version](https://github.com/homebridge/homebridge-config-ui-x/issues/2498)
