### PR TITLE
Fix sidebar scrollbars

### DIFF
--- a/ui/src/app/shared/layout/sidebar/sidebar.component.scss
+++ b/ui/src/app/shared/layout/sidebar/sidebar.component.scss
@@ -41,8 +41,10 @@
   }
 
   .link-wrapper {
+    overflow-x: hidden;
     overflow-y: auto;
     max-height: calc(100vh - 80px) !important;
+    scrollbar-width: thin;
 
     @media (max-width: 767px) {
       padding-bottom: 60px; // prevent menu items being hidden by URL bar on ios safari

--- a/ui/src/scss/themes/themes-dark.scss
+++ b/ui/src/scss/themes/themes-dark.scss
@@ -31,6 +31,8 @@
       }
 
       .link-wrapper {
+        scrollbar-color: $darkModePrimary transparent;
+
         .link {
           .link-row {
             &:hover {

--- a/ui/src/scss/themes/themes-light.scss
+++ b/ui/src/scss/themes/themes-light.scss
@@ -29,6 +29,8 @@
       }
 
       .link-wrapper {
+        scrollbar-color: $primary transparent;
+
         .link {
           .link-row {
             &:hover {


### PR DESCRIPTION
## :recycle: Current situation

If scrollbars are set to always display, the default vertical scrollbar causes a horizontal scrollbar to appear when the window height is reduced.

<img width="59" height="464" alt="Screenshot 2025-09-14 at 21 08 35" src="https://github.com/user-attachments/assets/bd07fe79-b2a2-4937-9017-9c42fbf7d2ab" />

## :bulb: Proposed solution

Hide the horizontal scrollbar and adjust the style of the vertical scrollbar.

<img width="59" height="463" alt="Screenshot 2025-09-14 at 21 07 40" src="https://github.com/user-attachments/assets/fedca7fc-77d6-449d-bbb1-84810a120929" />