### PR TITLE
Remove logging of every MessageEvent

### DIFF
--- a/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/manage-plugins/custom-plugins/custom-plugins.component.ts
@@ -280,8 +280,6 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
         case 'button.save.enabled':
           this.saveButtonDisabled = false
           break
-        default:
-          console.log(e) // eslint-disable-line no-console
       }
     }
   }


### PR DESCRIPTION
## :recycle: Current situation

Every MessageEvent is currently logged, which can be seen by running this in the console after invoking "Plugin Config":
```
window.postMessage('xxx')
``` 

As a result, there is an issue with the React Developer Tools Chrome extension (https://github.com/facebook/react/issues/27992) that causes log events every 500ms.


## :bulb: Proposed solution

Remove the logging.