### PR TITLE
Remove accessory focus style

### DIFF
--- a/ui/src/scss/components/accessories.scss
+++ b/ui/src/scss/components/accessories.scss
@@ -131,8 +131,7 @@
 
     @media (hover: hover) {
       &:active,
-      &:hover,
-      &:focus {
+      &:hover {
         opacity: 1;
         transform: scale(1.2);
       }


### PR DESCRIPTION
## :recycle: Current situation

The hover/active state persists after clicking the manage accessory button and closing the modal.

## :bulb: Proposed solution

Remove the focus style.