### PR TITLE
Remove margin on small tables

### DIFF
--- a/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.scss
+++ b/ui/src/app/modules/status/widgets/system-info-widget/system-info-widget.component.scss
@@ -1,3 +1,7 @@
+table.table-sm {
+  margin-bottom: 0;
+}
+
 table.table-sm th,
 table.table-sm td {
   padding-top: 0.3rem;


### PR DESCRIPTION
This prevents the `SystemInfoWidgetComponent` component from being scrolled down with the default table.