### PR TITLE
Support for localization of customUi html files

### DIFF
--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.controller.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject, Param, Query, Res } from '@nestjs/common'
+import { Controller, Get, Inject, Param, Query, Req, Res } from '@nestjs/common'
 import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger'
 
 import { PluginsSettingsUiService } from './plugins-settings-ui.service.js'
@@ -13,7 +13,8 @@ export class PluginsSettingsUiController {
   @Get('/:pluginName/*')
   @ApiOperation({ summary: 'Returns the HTML assets for a plugin\'s custom UI' })
   @ApiParam({ name: 'pluginName', type: 'string' })
-  async serveCustomUiAsset(@Res() reply, @Param('pluginName') pluginName, @Param('*') file, @Query('origin') origin: string, @Query('v') v?: string) {
-    return await this.pluginSettingsUiService.serveCustomUiAsset(reply, pluginName, file, origin, v)
+  async serveCustomUiAsset(@Req() req, @Res() reply, @Param('pluginName') pluginName, @Param('*') file, @Query('origin') origin: string, @Query('v') v?: string) {
+    const lang = req.headers['accept-language']?.split(',')[0].trim()
+    return await this.pluginSettingsUiService.serveCustomUiAsset(reply, pluginName, file, origin, v, lang)
   }
 }

--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -32,7 +32,7 @@ export class PluginsSettingsUiService {
   /**
    * Serve Custom HTML Assets for a plugin
    */
-  async serveCustomUiAsset(reply, pluginName: string, assetPath: string, origin: string, version?: string) {
+  async serveCustomUiAsset(reply, pluginName: string, assetPath: string, origin: string, version?: string, lang?: string) {
     try {
       if (!assetPath) {
         assetPath = 'index.html'
@@ -45,7 +45,7 @@ export class PluginsSettingsUiService {
       }
 
       const pluginUi: HomebridgePluginUiMetadata = (this.pluginUiMetadataCache.get(pluginName) as any)
-        || (await this.getPluginUiMetadata(pluginName))
+        || (await this.getPluginUiMetadata(pluginName, lang))
 
       const safeSuffix = normalize(assetPath).replace(/^(\.\.(\/|\\|$))+/, '')
       const filePath = join(pluginUi.publicPath, safeSuffix)
@@ -87,9 +87,9 @@ export class PluginsSettingsUiService {
   /**
    * Resolve the path for the custom plugin ui, and store it in the cache
    */
-  async getPluginUiMetadata(pluginName: string): Promise<HomebridgePluginUiMetadata> {
+  async getPluginUiMetadata(pluginName: string, lang?: string): Promise<HomebridgePluginUiMetadata> {
     try {
-      const pluginUi = await this.pluginsService.getPluginUiMetadata(pluginName)
+      const pluginUi = await this.pluginsService.getPluginUiMetadata(pluginName, lang)
       this.pluginUiMetadataCache.set(pluginName, pluginUi)
       this.pluginUiLastVersionCache.set(pluginName, pluginUi.plugin.installedVersion)
       return pluginUi

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1169,7 +1169,7 @@ export class PluginsService {
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('If you have not started the Docker container with ')
-    + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
+      + red('--restart=always') + yellow(' you may\n\rneed to manually start the container again.\n\r\n\r'))
     await new Promise(res => setTimeout(res, 800))
 
     client.emit('stdout', yellow('This process may take several minutes. Please be patient.\n\r'))
@@ -1540,7 +1540,7 @@ export class PluginsService {
   /**
    * Returns the custom ui path for a plugin
    */
-  public async getPluginUiMetadata(pluginName: string): Promise<HomebridgePluginUiMetadata> {
+  public async getPluginUiMetadata(pluginName: string, lang?: string): Promise<HomebridgePluginUiMetadata> {
     if (!this.installedPlugins) {
       await this.getInstalledPlugins()
     }
@@ -1550,7 +1550,24 @@ export class PluginsService {
     const schema = await readJson(resolve(fullPath, 'config.schema.json'))
     const customUiPath = resolve(fullPath, schema.customUiPath || 'homebridge-ui')
 
-    const publicPath = resolve(customUiPath, 'public')
+    let publicPath = resolve(customUiPath, 'public')
+
+    const configLang = this.configService.ui.lang;
+    if (configLang !== 'auto') {
+      lang = configLang || 'en'
+    }
+
+    let i18nPublicPath = resolve(publicPath, configLang)
+    if (await pathExists(resolve(i18nPublicPath, 'index.html'))) {
+      publicPath = i18nPublicPath
+    } else if (configLang.includes('-')) {
+      const baseLang = configLang.split('-')[0]
+      i18nPublicPath = resolve(publicPath, baseLang)
+      if (await pathExists(resolve(i18nPublicPath, 'index.html'))) {
+        publicPath = i18nPublicPath
+      }
+    }
+
     const serverPath = resolve(customUiPath, 'server.js')
     const devServer = plugin.private ? schema.customUiDevServer : null
 


### PR DESCRIPTION
## :recycle: Current situation

As far as I am aware, there is currently no good way to localize html used for customUi. The method I'm using in [my](https://github.com/mpatfield/homebridge-dummy/blob/latest/src/homebridge-ui/ui.ts) [plugins](https://github.com/mpatfield/homebridge-easy-mqtt/blob/latest/src/homebridge-ui/ui.ts) is to use a ui.js script to fetch the translations via a server and inject them client side.

## :bulb: Proposed solution

Similar to https://github.com/homebridge/homebridge-config-ui-x/pull/2598, this PR allows a plugin to define language-specific index.html files

The proposed structure is:

- homebridge-ui/
  - public/
    - de/
      - index.html
    - es/
      - index.html
    - etc...
    - index.html  <-- default 'en'
  - server.js

However, I am totally open to other folder structure suggestions.

## :gear: Release Notes

Add support for localized customUi index.html files

## :heavy_plus_sign: Additional Information

N/A

### Testing

Couldn't find anywhere to add tests for this but happy to do so if I'm given some guidance

### Reviewer Nudging

Main logic is in `plugins.service.ts`
