### PR TITLE
Update accessories data on UI change

### DIFF
--- a/src/modules/accessories/accessories.service.ts
+++ b/src/modules/accessories/accessories.service.ts
@@ -124,6 +124,7 @@ export class AccessoriesService {
             try {
               await service.setCharacteristic(msg.set.iid, msg.set.value)
               const hapServices = await this.loadAccessories()
+              client.emit('accessories-data', hapServices)
 
               // Do a refresh to check if any accessories changed after this action
               setTimeout(() => {
@@ -143,7 +144,7 @@ export class AccessoriesService {
     const monitor = await this.hapClient.monitorCharacteristics()
 
     const updateHandler = (data: ServiceType | MatterService) => {
-      client.emit('accessories-data', data)
+      client.emit('accessories-data', [data])
     }
     monitor.on('service-update', updateHandler)
 


### PR DESCRIPTION
## :recycle: Current situation

Accessories do not update on change until the page is refreshed (the Home app still updates).

## :bulb: Proposed solution

Emit `accessories-data` event.

https://github.com/user-attachments/assets/0dd459ae-b505-489d-aca9-0f5e5cfea53b

https://github.com/user-attachments/assets/cfa12085-8496-41a0-8631-87cc9d2134f3