### PR TITLE
Check for default CHANGELOG

### DIFF
--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -1422,6 +1422,16 @@ export class PluginsService {
             latestVersion,
           }
         } catch (e) {
+          const changelog = await firstValueFrom(this.httpService.get(`https://raw.githubusercontent.com/${match[1]}/${match[2]}/HEAD/CHANGELOG.md`))
+          if (changelog.status === 200) {
+            return {
+              name: null,
+              notes: null,
+              changelog: changelog.data,
+              latestVersion,
+            }
+          }
+
           throw new NotFoundException()
         }
       }


### PR DESCRIPTION
## :recycle: Current situation

Root level CHANGELOG.md files are ignored if there are no releases.

## :bulb: Proposed solution

Check CHANGELOG file if there are no releases.

### Testing

Update this plugin:
https://github.com/plasticrake/homebridge-tplink-smarthome