### PR TITLE
chore(deps): replace tcp-port-used with is-tcp-port-used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "dayjs": "1.11.20",
         "fastify": "5.8.4",
         "fs-extra": "11.3.4",
+        "is-tcp-port-used": "1.0.2",
         "jsonwebtoken": "9.0.3",
         "lodash": "4.17.23",
         "node-cache": "5.1.2",
@@ -58,7 +59,6 @@
         "systeminformation": "5.31.5",
         "tail": "2.2.6",
         "tar": "7.5.13",
-        "tcp-port-used": "1.0.2",
         "unzipper": "0.12.3"
       },
       "bin": {
@@ -79,7 +79,6 @@
         "@types/passport-jwt": "^4.0.1",
         "@types/semver": "^7.7.1",
         "@types/tail": "^2.2.3",
-        "@types/tcp-port-used": "^1.0.4",
         "@types/unzipper": "^0.10.11",
         "@vitest/coverage-v8": "^4.1.2",
         "concurrently": "^9.2.1",
@@ -2173,9 +2172,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2193,9 +2189,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2213,9 +2206,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2233,9 +2223,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2253,9 +2240,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2273,9 +2257,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2293,9 +2274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2313,9 +2291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,9 +2493,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,9 +2510,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,9 +2527,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2578,9 +2544,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,9 +2561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,9 +2578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,9 +2852,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2916,9 +2870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2937,9 +2888,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2958,9 +2906,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2979,9 +2924,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3000,9 +2942,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3392,13 +3331,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/tail/-/tail-2.2.3.tgz",
       "integrity": "sha512-Hnf352egOlDR4nVTaGX0t/kmTNXHMdovF2C7PVDFtHTHJPFmIspOI1b86vEOxU7SfCq/dADS7ptbqgG/WGGxnA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/tcp-port-used": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/tcp-port-used/-/tcp-port-used-1.0.4.tgz",
-      "integrity": "sha512-0vQ4fz9TTM4bCdllYWEJ2JHBUXR9xqPtc70dJ7BMRDVfvZyYdrgey3nP5RRcVj+qAgnHJM8r9fvgrfnPMxdnhA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5034,7 +4966,9 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -7115,15 +7049,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
-    "node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
@@ -7217,6 +7142,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-tcp-port-used/-/is-tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-4P1jnpfYAD6Gij7ilKXkigSYLknQGsOOcNYLG8FWefHfxElddRZbmVqPT+oXhdznUDqgOMJwXaVpvBeEx3Ivxg==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -7227,26 +7158,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "license": "MIT"
-    },
-    "node_modules/is2": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
-      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "ip-regex": "^4.1.0",
-        "is-url": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=v0.10.0"
       }
     },
     "node_modules/isarray": {
@@ -7706,9 +7617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7730,9 +7638,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7754,9 +7659,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7778,9 +7680,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10890,39 +10789,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/tcp-port-used": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4.3.1",
-        "is2": "^2.0.6"
-      }
-    },
-    "node_modules/tcp-port-used/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tcp-port-used/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "dayjs": "1.11.20",
     "fastify": "5.8.4",
     "fs-extra": "11.3.4",
+    "is-tcp-port-used": "1.0.2",
     "jsonwebtoken": "9.0.3",
     "lodash": "4.17.23",
     "node-cache": "5.1.2",
@@ -118,7 +119,6 @@
     "systeminformation": "5.31.5",
     "tail": "2.2.6",
     "tar": "7.5.13",
-    "tcp-port-used": "1.0.2",
     "unzipper": "0.12.3"
   },
   "optionalDependencies": {
@@ -141,7 +141,6 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/semver": "^7.7.1",
     "@types/tail": "^2.2.3",
-    "@types/tcp-port-used": "^1.0.4",
     "@types/unzipper": "^0.10.11",
     "@vitest/coverage-v8": "^4.1.2",
     "concurrently": "^9.2.1",

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -24,12 +24,12 @@ import { fileURLToPath } from 'node:url'
 import axios from 'axios'
 import { program } from 'commander'
 import { mkdirp, pathExists, pathExistsSync, readJson, readJsonSync, remove, writeJson } from 'fs-extra/esm'
+import { check as tcpCheck } from 'is-tcp-port-used'
 import ora from 'ora'
 import { gt, gte, parse } from 'semver'
 import { networkInterfaceDefault, networkInterfaces } from 'systeminformation'
 import { Tail } from 'tail'
 import { extract } from 'tar'
-import { check as tcpCheck } from 'tcp-port-used'
 
 import { RE_COLON, RE_NON_SCOPED, RE_PLUGIN_NAME, RE_SCOPED, RE_SERVICE_NAME } from '../core/regex.constants.js'
 import { DarwinInstaller } from './platforms/darwin.js'
@@ -696,7 +696,7 @@ export class HomebridgeServiceHelper {
    * Checks if the port is currently in use by another process
    */
   public async portCheck() {
-    const inUse = await tcpCheck(this.uiPort)
+    const inUse = await tcpCheck({ port: this.uiPort })
     if (inUse) {
       this.logger(`Port ${this.uiPort} is already in use by another process on this host.`, 'fail')
       this.logger('You can specify another port using the --port flag, e.g.:', 'fail')
@@ -942,7 +942,7 @@ export class HomebridgeServiceHelper {
     const randomPort = () => Math.floor(Math.random() * (52000 - 51000 + 1) + 51000)
 
     let port = randomPort()
-    while (await tcpCheck(port)) {
+    while (await tcpCheck({ port })) {
       port = randomPort()
     }
 
@@ -1000,7 +1000,7 @@ export class HomebridgeServiceHelper {
       }
 
       // Check if port is still in use
-      if (!await tcpCheck(Number.parseInt(currentConfig.bridge.port.toString(), 10))) {
+      if (!await tcpCheck({ port: Number.parseInt(currentConfig.bridge.port.toString(), 10) })) {
         return
       }
 

--- a/src/modules/server/server.service.ts
+++ b/src/modules/server/server.service.ts
@@ -25,9 +25,9 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common'
 import { pathExists, readJson, remove, writeJson } from 'fs-extra/esm'
+import { check as tcpCheck } from 'is-tcp-port-used'
 import NodeCache from 'node-cache'
 import { networkInterfaces } from 'systeminformation'
-import { check as tcpCheck } from 'tcp-port-used'
 
 import { ConfigService } from '../../core/config/config.service.js'
 import { HomebridgeIpcService } from '../../core/homebridge-ipc/homebridge-ipc.service.js'
@@ -1067,7 +1067,7 @@ export class ServerService {
     const randomPort = () => Math.floor(Math.random() * (max - min + 1) + min)
 
     let port = randomPort()
-    while (await tcpCheck(port)) {
+    while (await tcpCheck({ port })) {
       port = randomPort()
     }
 
@@ -1106,7 +1106,7 @@ export class ServerService {
 
     // Find first available port
     for (let port = min; port <= max; port += 1) {
-      if (!usedMatterPorts.has(port) && !await tcpCheck(port)) {
+      if (!usedMatterPorts.has(port) && !await tcpCheck({ port })) {
         return { port }
       }
     }


### PR DESCRIPTION
## :recycle: Current situation

The project uses `tcp-port-used` to check if TCP ports are available. It has not been updated since 2020 and also brings in 2 unnecessary dependencies (`debug`, `is2`), and requires a separate `@types/tcp-port-used` package for TypeScript.

## :bulb: Proposed solution

Swap (`tcp-port-used` + `@types/tcp-port-used`) with `is-tcp-port-used`. Same functionality, no extra dependencies, types are included out of the box.

Used in two files:                                              
- `src/bin/hb-service.ts`: port checks during service startup and port generation.
- `src/modules/server/server.service.ts`: random port and Matter port allocation.     

- Changes:
  - I updated imports in both files.                         
  - Changed 5 call sites from tcpCheck(port) to tcpCheck({ port }) (options object instead of positional args)
  - Removed tcp-port-used and @types/tcp-port-used from package.json                                                             
  - Added is-tcp-port-used

Removes 153 lines and adds 18. :D 

## :gear: Release Notes

- No breaking changes, no changes from user's POV.

## :heavy_plus_sign: Additional Information

- N/A

### Testing

- No test changes needed. It was a drop in replacement. Project compiles cleanly with `tsc --noEmit`.

### Reviewer Nudging

- I guess start with the two source files to see the call site changes, and then package.json for the dependency swap.