### PR TITLE
[Part 1] Robust logging in HBService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - fix(ui): remove stale terminal socket listeners on destroy
 - fix(plugins): resolve `savePluginConfig()` ack so custom ui saves no longer hang (#2869)
 - fix(plugins): remove stale custom ui socket listeners on destroy (#2873)
+- refactor(hb-service): level-based logger — `hb-service run` now writes level tags like `[INFO]` and `[VERBOSE]` into `homebridge.log` (#2874) (@mpatfield)
 
 ### Other Changes
 

--- a/src/bin/base-platform.ts
+++ b/src/bin/base-platform.ts
@@ -5,45 +5,45 @@ import process from 'node:process'
 export class BasePlatform {
   constructor(
     public hbService: HomebridgeServiceHelper,
-  ) {}
+  ) { }
 
   public async install(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async uninstall(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async start(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async stop(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async restart(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async beforeStart(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async rebuild(all = false): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
   public async viewLogs(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 
@@ -58,10 +58,10 @@ export class BasePlatform {
     return null
   }
 
-  public async updateNodejs(job: { target: string, rebuild: boolean }): Promise<void> {}
+  public async updateNodejs(job: { target: string, rebuild: boolean }): Promise<void> { }
 
   public async updateHomebridgePackage(): Promise<void> {
-    this.hbService.logger('This command has not been implemented on this platform.', 'fail')
+    this.hbService.logger.error('This command has not been implemented on this platform.')
     process.exit(0)
   }
 }

--- a/src/bin/base-platform.ts
+++ b/src/bin/base-platform.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 export class BasePlatform {
   constructor(
     public hbService: HomebridgeServiceHelper,
-  ) { }
+  ) {}
 
   public async install(): Promise<void> {
     this.hbService.logger.error('This command has not been implemented on this platform.')
@@ -58,7 +58,7 @@ export class BasePlatform {
     return null
   }
 
-  public async updateNodejs(job: { target: string, rebuild: boolean }): Promise<void> { }
+  public async updateNodejs(job: { target: string, rebuild: boolean }): Promise<void> {}
 
   public async updateHomebridgePackage(): Promise<void> {
     this.hbService.logger.error('This command has not been implemented on this platform.')

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -47,7 +47,6 @@ const __dirname = dirname(__filename)
 type Action = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'rebuild' | 'run' | 'add' | 'remove' | 'logs' | 'view' | 'update-node' | 'update-homebridge' | 'before-start' | 'status'
 
 class Logger {
-
   constructor(
     private readonly action: Action,
     private readonly logFile: WriteStream | NodeJS.WriteStream,
@@ -78,19 +77,16 @@ class Logger {
   }
 
   private _log(msg: string, level: 'info' | 'success' | 'error' | 'warn' | 'debug' | 'verbose') {
-
     if (this.action === 'run') {
       msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
         + `\x1B[36m[HB Supervisor]\x1B[0m [${level.toUpperCase()}] ${msg}`
 
       if (this.logFile) {
         this.logFile.write(`${msg}\n`)
-
       } else {
         console.log(msg)
       }
     } else {
-
       let oraLevel: 'info' | 'succeed' | 'fail' | 'warn'
       switch (level) {
         case 'info':
@@ -155,9 +151,9 @@ export class HomebridgeServiceHelper {
 
   get logger(): Logger {
     if (!this._logger) {
-      this._logger = new Logger(this.action, this.logFile);
+      this._logger = new Logger(this.action, this.logFile)
     }
-    return this._logger;
+    return this._logger
   }
 
   constructor() {
@@ -310,7 +306,6 @@ export class HomebridgeServiceHelper {
       }
     }
   }
-
 
   /**
    * Sets the required environment variables passed on to the child processes
@@ -518,12 +513,12 @@ export class HomebridgeServiceHelper {
       this.logger.log('Stopping services...')
       try {
         this.homebridge.kill()
-      } catch (e) { }
+      } catch (e) {}
 
       setTimeout(() => {
         try {
           this.homebridge.kill('SIGKILL')
-        } catch (e) { }
+        } catch (e) {}
         process.exit(1282)
       }, 7000)
     }
@@ -780,7 +775,7 @@ export class HomebridgeServiceHelper {
         'WARNING: It looks like you are running Node.js via NVM (Node Version Manager).\n'
         + '  Using hb-service with NVM may not work unless you have configured NVM for the\n'
         + '  user this service will run as. See https://homebridge.io/w/JUZ2g for instructions on how\n'
-        + '  to remove NVM, then follow the wiki instructions to install Node.js and Homebridge.'
+        + '  to remove NVM, then follow the wiki instructions to install Node.js and Homebridge.',
       )
     }
   }

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -34,6 +34,7 @@ import { extract } from 'tar'
 import { check as tcpCheck } from 'tcp-port-used'
 
 import { RE_COLON, RE_NON_SCOPED, RE_PLUGIN_NAME, RE_SCOPED, RE_SERVICE_NAME } from '../core/regex.constants.js'
+import { Logger } from './logger.js'
 import { DarwinInstaller } from './platforms/darwin.js'
 import { FreeBSDInstaller } from './platforms/freebsd.js'
 import { LinuxInstaller } from './platforms/linux.js'
@@ -45,72 +46,6 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 type Action = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'rebuild' | 'run' | 'add' | 'remove' | 'logs' | 'view' | 'update-node' | 'update-homebridge' | 'before-start' | 'status'
-
-class Logger {
-  // Read `action` and `logFile` from the service helper at write time —
-  // `logFile` is not assigned until `startLog()` runs, which happens after
-  // the first log calls in the `run` path, so it must not be snapshotted here.
-  constructor(
-    private readonly hbService: HomebridgeServiceHelper,
-  ) {}
-
-  log(msg: string) {
-    this._log(msg, 'info')
-  }
-
-  success(msg: string) {
-    this._log(msg, 'success')
-  }
-
-  error(msg: string) {
-    this._log(msg, 'error')
-  }
-
-  warn(msg: string) {
-    this._log(msg, 'warn')
-  }
-
-  debug(msg: string) {
-    this._log(msg, 'debug')
-  }
-
-  verbose(msg: string) {
-    this._log(msg, 'verbose')
-  }
-
-  private _log(msg: string, level: 'info' | 'success' | 'error' | 'warn' | 'debug' | 'verbose') {
-    if (this.hbService.action === 'run') {
-      msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
-        + `\x1B[36m[HB Supervisor]\x1B[0m [${level.toUpperCase()}] ${msg}`
-
-      if (this.hbService.logFile) {
-        this.hbService.logFile.write(`${msg}\n`)
-      } else {
-        console.log(msg)
-      }
-    } else {
-      let oraLevel: 'info' | 'succeed' | 'fail' | 'warn'
-      switch (level) {
-        case 'info':
-        case 'debug':
-        case 'verbose':
-          oraLevel = 'info'
-          break
-        case 'success':
-          oraLevel = 'succeed'
-          break
-        case 'error':
-          oraLevel = 'fail'
-          break
-        case 'warn':
-          oraLevel = 'warn'
-          break
-      }
-
-      ora()[oraLevel](msg)
-    }
-  }
-}
 
 export class HomebridgeServiceHelper {
   public action: Action

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -44,8 +44,78 @@ process.title = 'hb-service'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+type Action = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'rebuild' | 'run' | 'add' | 'remove' | 'logs' | 'view' | 'update-node' | 'update-homebridge' | 'before-start' | 'status'
+
+class Logger {
+
+  constructor(
+    private readonly action: Action,
+    private readonly logFile: WriteStream | NodeJS.WriteStream,
+  ) { }
+
+  log(msg: string) {
+    this._log(msg, 'info')
+  }
+
+  success(msg: string) {
+    this._log(msg, 'success')
+  }
+
+  error(msg: string) {
+    this._log(msg, 'error')
+  }
+
+  warn(msg: string) {
+    this._log(msg, 'warn')
+  }
+
+  debug(msg: string) {
+    this._log(msg, 'debug')
+  }
+
+  verbose(msg: string) {
+    this._log(msg, 'verbose')
+  }
+
+  private _log(msg: string, level: 'info' | 'success' | 'error' | 'warn' | 'debug' | 'verbose') {
+
+    if (this.action === 'run') {
+      msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
+        + `\x1B[36m[HB Supervisor]\x1B[0m [${level.toUpperCase()}] ${msg}`
+
+      if (this.logFile) {
+        this.logFile.write(`${msg}\n`)
+
+      } else {
+        console.log(msg)
+      }
+    } else {
+
+      let oraLevel: 'info' | 'succeed' | 'fail' | 'warn'
+      switch (level) {
+        case 'info':
+        case 'debug':
+        case 'verbose':
+          oraLevel = 'info'
+          break
+        case 'success':
+          oraLevel = 'succeed'
+          break
+        case 'error':
+          oraLevel = 'fail'
+          break
+        case 'warn':
+          oraLevel = 'warn'
+          break
+      }
+
+      ora()[oraLevel](msg)
+    }
+  }
+}
+
 export class HomebridgeServiceHelper {
-  public action: 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'rebuild' | 'run' | 'add' | 'remove' | 'logs' | 'view' | 'update-node' | 'update-homebridge' | 'before-start' | 'status'
+  public action: Action
   public selfPath = __filename
   public serviceName = 'Homebridge'
   public storagePath: string
@@ -54,7 +124,8 @@ export class HomebridgeServiceHelper {
   public enableHbServicePluginManagement = false
   public asUser: string
   public addGroup: string
-  private log: WriteStream | NodeJS.WriteStream
+  public _logger: Logger
+  private logFile: WriteStream | NodeJS.WriteStream
   private homebridgeModulePath: string
   private homebridgePackage: { version: string, bin: { homebridge: string } }
   private homebridgeBinary: string
@@ -82,6 +153,13 @@ export class HomebridgeServiceHelper {
     return resolve(this.storagePath, 'homebridge.log')
   }
 
+  get logger(): Logger {
+    if (!this._logger) {
+      this._logger = new Logger(this.action, this.logFile);
+    }
+    return this._logger;
+  }
+
   constructor() {
     // Check the node.js version
     this.nodeVersionCheck()
@@ -101,7 +179,7 @@ export class HomebridgeServiceHelper {
         this.installer = new FreeBSDInstaller(this)
         break
       default:
-        this.logger(`ERROR: This command is not supported on ${platform()}.`, 'fail')
+        this.logger.error(`ERROR: This command is not supported on ${platform()}.`)
         process.exit(1)
     }
 
@@ -142,12 +220,12 @@ export class HomebridgeServiceHelper {
     switch (this.action) {
       case 'install': {
         this.nvmCheck()
-        this.logger(`Installing ${this.serviceName} service...`)
+        this.logger.log(`Installing ${this.serviceName} service...`)
         this.installer.install()
         break
       }
       case 'uninstall': {
-        this.logger(`Removing ${this.serviceName} service...`)
+        this.logger.log(`Removing ${this.serviceName} service...`)
         this.installer.uninstall()
         break
       }
@@ -160,12 +238,12 @@ export class HomebridgeServiceHelper {
         break
       }
       case 'restart': {
-        this.logger(`Restarting ${this.serviceName} service...`)
+        this.logger.log(`Restarting ${this.serviceName} service...`)
         this.installer.restart()
         break
       }
       case 'rebuild': {
-        this.logger(`Rebuilding for Node.js ${process.version}...`)
+        this.logger.log(`Rebuilding for Node.js ${process.version}...`)
         this.installer.rebuild(program.args.includes('--all'))
         break
       }
@@ -233,22 +311,6 @@ export class HomebridgeServiceHelper {
     }
   }
 
-  /**
-   * Logger function, log to homebridge.log file when possible
-   */
-  public logger(msg: string, level: 'info' | 'succeed' | 'fail' | 'warn' = 'info') {
-    if (this.action === 'run') {
-      msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
-        + `\x1B[36m[HB Supervisor]\x1B[0m ${msg}`
-      if (this.log) {
-        this.log.write(`${msg}\n`)
-      } else {
-        console.log(msg)
-      }
-    } else {
-      ora()[level](msg)
-    }
-  }
 
   /**
    * Sets the required environment variables passed on to the child processes
@@ -256,7 +318,7 @@ export class HomebridgeServiceHelper {
   private setEnv() {
     // Ensure service name is valid
     if (!RE_SERVICE_NAME.test(this.serviceName)) {
-      this.logger('Service name must not contain spaces or special characters.', 'fail')
+      this.logger.error('Service name must not contain spaces or special characters.')
       process.exit(1)
     }
 
@@ -272,7 +334,7 @@ export class HomebridgeServiceHelper {
     // Certain commands are not supported when running in Docker
     if (process.env.CONFIG_UI_VERSION && process.env.HOMEBRIDGE_VERSION && process.env.QEMU_ARCH) {
       if (platform() === 'linux' && ['install', 'uninstall', 'start', 'stop', 'restart', 'logs'].includes(this.action)) {
-        this.logger(`Sorry, the ${this.action} command is not supported in Docker.`, 'fail')
+        this.logger.error(`Sorry, the ${this.action} command is not supported in Docker.`)
         process.exit(1)
       }
     }
@@ -305,16 +367,16 @@ export class HomebridgeServiceHelper {
    */
   private async startLog() {
     if (this.stdout === true) {
-      this.log = process.stdout
+      this.logFile = process.stdout
       return
     }
 
     // Work out the log path
-    this.logger(`Logging to ${this.logPath}.`)
+    this.logger.log(`Logging to ${this.logPath}.`)
 
     // Redirect all stdout to the log file
-    this.log = createWriteStream(this.logPath, { flags: 'a' })
-    process.stdout.write = process.stderr.write = this.log.write.bind(this.log)
+    this.logFile = createWriteStream(this.logPath, { flags: 'a' })
+    process.stdout.write = process.stderr.write = this.logFile.write.bind(this.logFile)
   }
 
   private async readConfig() {
@@ -359,9 +421,9 @@ export class HomebridgeServiceHelper {
       // final write() land out of order — and on some filesystems
       // leave sparse \0 bytes between the truncated tail and the new
       // content.
-      const corked = this.log && typeof (this.log as any).cork === 'function'
+      const corked = this.logFile && typeof (this.logFile as any).cork === 'function'
       if (corked) {
-        (this.log as any).cork()
+        (this.logFile as any).cork()
       }
       try {
         await logFileHandle.read(logBuffer, 0, truncateSize, logStartPosition)
@@ -370,11 +432,11 @@ export class HomebridgeServiceHelper {
       } finally {
         await logFileHandle.close()
         if (corked) {
-          (this.log as any).uncork()
+          (this.logFile as any).uncork()
         }
       }
     } catch (e) {
-      this.logger(`Failed to truncate log file: ${e.message}.`, 'fail')
+      this.logger.error(`Failed to truncate log file: ${e.message}.`)
     }
   }
 
@@ -383,13 +445,13 @@ export class HomebridgeServiceHelper {
    */
   private async launch() {
     if (platform() !== 'win32' && process.getuid() === 0 && !this.allowRunRoot) {
-      this.logger('The hb-service run command should not be executed as root.')
-      this.logger('Use the --allow-root flag to force the service to run as the root user.')
+      this.logger.log('The hb-service run command should not be executed as root.')
+      this.logger.log('Use the --allow-root flag to force the service to run as the root user.')
       process.exit(0)
     }
 
-    this.logger(`Homebridge storage path: ${this.storagePath}.`)
-    this.logger(`Homebridge config path: ${process.env.UIX_CONFIG_PATH}.`)
+    this.logger.log(`Homebridge storage path: ${this.storagePath}.`)
+    this.logger.log(`Homebridge config path: ${process.env.UIX_CONFIG_PATH}.`)
 
     // Start the interval to truncate the logs every two hours
     setInterval(() => {
@@ -408,21 +470,21 @@ export class HomebridgeServiceHelper {
       await this.configCheck()
 
       // Log os info
-      this.logger(`OS: ${type()} ${release()} ${arch()}.`)
-      this.logger(`Node.js ${process.version} ${process.execPath}.`)
+      this.logger.log(`OS: ${type()} ${release()} ${arch()}.`)
+      this.logger.log(`Node.js ${process.version} ${process.execPath}.`)
 
       // Work out the homebridge binary path
       this.homebridgeBinary = await this.findHomebridgePath()
-      this.logger(`Homebridge path: ${this.homebridgeBinary}.`)
+      this.logger.log(`Homebridge path: ${this.homebridgeBinary}.`)
 
       // Load startup options if they exist
       await this.loadHomebridgeStartupOptions()
 
       // Get the standalone ui binary on this system
       this.uiBinary = resolve(process.env.UIX_BASE_PATH, 'dist', 'bin', 'standalone.js')
-      this.logger(`UI path: ${this.uiBinary}.`)
+      this.logger.log(`UI path: ${this.uiBinary}.`)
     } catch (e) {
-      this.logger(e.message)
+      this.logger.log(e.message)
       process.exit(1)
     }
 
@@ -439,7 +501,7 @@ export class HomebridgeServiceHelper {
 
     // Delay the launch of homebridge on Raspberry Pi 1/Zero by 20 seconds
     if (cpus().length === 1 && arch() === 'arm') {
-      this.logger('Delaying Homebridge startup by 20 seconds on low powered server.')
+      this.logger.log('Delaying Homebridge startup by 20 seconds on low powered server.')
       setTimeout(() => {
         this.runHomebridge()
       }, 20000)
@@ -453,15 +515,15 @@ export class HomebridgeServiceHelper {
    */
   private startExitHandler() {
     const exitHandler = () => {
-      this.logger('Stopping services...')
+      this.logger.log('Stopping services...')
       try {
         this.homebridge.kill()
-      } catch (e) {}
+      } catch (e) { }
 
       setTimeout(() => {
         try {
           this.homebridge.kill('SIGKILL')
-        } catch (e) {}
+        } catch (e) { }
         process.exit(1282)
       }, 7000)
     }
@@ -475,8 +537,8 @@ export class HomebridgeServiceHelper {
    */
   private runHomebridge() {
     if (!this.homebridgeBinary || !pathExistsSync(this.homebridgeBinary)) {
-      this.logger('Could not find Homebridge. Make sure you have installed Homebridge using the -g flag then restart.', 'fail')
-      this.logger('npm install -g --unsafe-perm homebridge', 'fail')
+      this.logger.error('Could not find Homebridge. Make sure you have installed Homebridge using the -g flag then restart.')
+      this.logger.error('npm install -g --unsafe-perm homebridge')
       return
     }
 
@@ -487,11 +549,11 @@ export class HomebridgeServiceHelper {
     }
 
     if (this.homebridgeOpts.length) {
-      this.logger(`Starting Homebridge with extra flags: ${this.homebridgeOpts.join(' ')}.`)
+      this.logger.log(`Starting Homebridge with extra flags: ${this.homebridgeOpts.join(' ')}.`)
     }
 
     if (Object.keys(this.homebridgeCustomEnv).length) {
-      this.logger(`Starting Homebridge with custom env: ${JSON.stringify(this.homebridgeCustomEnv)}.`)
+      this.logger.log(`Starting Homebridge with custom env: ${JSON.stringify(this.homebridgeCustomEnv)}.`)
     }
 
     // Env setup
@@ -531,7 +593,7 @@ export class HomebridgeServiceHelper {
       this.ipcService.setHomebridgeVersion(this.homebridgePackage.version)
     }
 
-    this.logger(`Started Homebridge v${this.homebridgePackage.version} with PID: ${this.homebridge.pid}.`)
+    this.logger.log(`Started Homebridge v${this.homebridgePackage.version} with PID: ${this.homebridge.pid}.`)
 
     // Buffer per-stream output and flush whole lines so concurrent
     // stdout/stderr writes don't interleave mid-line in the log file.
@@ -544,7 +606,7 @@ export class HomebridgeServiceHelper {
       let consumed = 0
       let idx = buf.indexOf('\n', consumed)
       while (idx !== -1) {
-        this.log.write(buf.slice(consumed, idx + 1))
+        this.logFile.write(buf.slice(consumed, idx + 1))
         consumed = idx + 1
         idx = buf.indexOf('\n', consumed)
       }
@@ -570,11 +632,11 @@ export class HomebridgeServiceHelper {
       outBuf += outDecoder.end()
       errBuf += errDecoder.end()
       if (outBuf) {
-        this.log.write(outBuf.endsWith('\n') ? outBuf : `${outBuf}\n`)
+        this.logFile.write(outBuf.endsWith('\n') ? outBuf : `${outBuf}\n`)
         outBuf = ''
       }
       if (errBuf) {
-        this.log.write(errBuf.endsWith('\n') ? errBuf : `${errBuf}\n`)
+        this.logFile.write(errBuf.endsWith('\n') ? errBuf : `${errBuf}\n`)
         errBuf = ''
       }
       this.handleHomebridgeClose(code, signal)
@@ -587,13 +649,13 @@ export class HomebridgeServiceHelper {
    * @param signal
    */
   private handleHomebridgeClose(code: number, signal: string) {
-    this.logger(`Homebridge process ended. Code: ${code}, signal: ${signal}.`)
+    this.logger.log(`Homebridge process ended. Code: ${code}, signal: ${signal}.`)
 
     this.checkForStaleHomebridgeProcess()
     this.refreshHomebridgePackage()
 
     setTimeout(() => {
-      this.logger('Restarting Homebridge...')
+      this.logger.log('Restarting Homebridge...')
       this.runHomebridge()
     }, 5000)
   }
@@ -612,7 +674,7 @@ export class HomebridgeServiceHelper {
       // Extract services
       this.ipcService = ui.get(main.HomebridgeIpcService)
     } catch (e) {
-      this.logger('The user interface threw an unhandled error.')
+      this.logger.log('The user interface threw an unhandled error.')
       console.error(e)
 
       setTimeout(() => {
@@ -688,10 +750,10 @@ export class HomebridgeServiceHelper {
       if (await pathExists(this.homebridgeModulePath)) {
         this.homebridgePackage = await readJson(join(this.homebridgeModulePath, 'package.json'))
       } else {
-        this.logger(`Homebridge not longer found at ${this.homebridgeModulePath}.`, 'fail')
+        this.logger.error(`Homebridge not longer found at ${this.homebridgeModulePath}.`)
         this.homebridgeModulePath = undefined
         this.homebridgeBinary = await this.findHomebridgePath()
-        this.logger(`Found new Homebridge path: ${this.homebridgeBinary}.`)
+        this.logger.log(`Found new Homebridge path: ${this.homebridgeBinary}.`)
       }
     } catch (e) {
       console.log(e)
@@ -704,7 +766,7 @@ export class HomebridgeServiceHelper {
   private nodeVersionCheck() {
     // 64 = v10;
     if (Number.parseInt(process.versions.modules, 10) < 64) {
-      this.logger(`Node.js v10.13.0 or greater is required, current: ${process.version}.`, 'fail')
+      this.logger.error(`Node.js v10.13.0 or greater is required, current: ${process.version}.`)
       process.exit(1)
     }
   }
@@ -714,12 +776,11 @@ export class HomebridgeServiceHelper {
    */
   private nvmCheck() {
     if (process.execPath.includes('nvm') && platform() === 'linux') {
-      this.logger(
+      this.logger.warn(
         'WARNING: It looks like you are running Node.js via NVM (Node Version Manager).\n'
         + '  Using hb-service with NVM may not work unless you have configured NVM for the\n'
         + '  user this service will run as. See https://homebridge.io/w/JUZ2g for instructions on how\n'
-        + '  to remove NVM, then follow the wiki instructions to install Node.js and Homebridge.',
-        'warn',
+        + '  to remove NVM, then follow the wiki instructions to install Node.js and Homebridge.'
       )
     }
   }
@@ -745,7 +806,7 @@ export class HomebridgeServiceHelper {
 
     console.log('')
 
-    this.logger('Homebridge setup complete.', 'succeed')
+    this.logger.success('Homebridge setup complete.')
   }
 
   /**
@@ -754,9 +815,9 @@ export class HomebridgeServiceHelper {
   public async portCheck() {
     const inUse = await tcpCheck(this.uiPort)
     if (inUse) {
-      this.logger(`Port ${this.uiPort} is already in use by another process on this host.`, 'fail')
-      this.logger('You can specify another port using the --port flag, e.g.:', 'fail')
-      this.logger(`hb-service ${this.action} --port 8581`, 'fail')
+      this.logger.error(`Port ${this.uiPort} is already in use by another process on this host.`)
+      this.logger.error('You can specify another port using the --port flag, e.g.:')
+      this.logger.error(`hb-service ${this.action} --port 8581`)
       process.exit(1)
     }
   }
@@ -766,12 +827,12 @@ export class HomebridgeServiceHelper {
    */
   public async storagePathCheck() {
     if (platform() === 'darwin' && !await pathExists(dirname(this.storagePath))) {
-      this.logger(`Cannot create Homebridge storage directory, base path does not exist: ${dirname(this.storagePath)}.`, 'fail')
+      this.logger.error(`Cannot create Homebridge storage directory, base path does not exist: ${dirname(this.storagePath)}.`)
       process.exit(1)
     }
 
     if (!await pathExists(this.storagePath)) {
-      this.logger(`Creating Homebridge directory: ${this.storagePath}.`)
+      this.logger.log(`Creating Homebridge directory: ${this.storagePath}.`)
       await mkdirp(this.storagePath)
       await this.chownPath(this.storagePath)
     }
@@ -786,7 +847,7 @@ export class HomebridgeServiceHelper {
     let restartRequired = false
 
     if (!await pathExists(process.env.UIX_CONFIG_PATH)) {
-      this.logger(`Creating default config.json: ${process.env.UIX_CONFIG_PATH}.`)
+      this.logger.log(`Creating default config.json: ${process.env.UIX_CONFIG_PATH}.`)
       await this.createDefaultConfig()
       restartRequired = true
     }
@@ -802,7 +863,7 @@ export class HomebridgeServiceHelper {
 
       // If the config block does not exist, then create it
       if (!uiConfigBlock) {
-        this.logger(`Adding missing UI platform block to ${process.env.UIX_CONFIG_PATH}.`, 'info')
+        this.logger.log(`Adding missing UI platform block to ${process.env.UIX_CONFIG_PATH}.`)
         uiConfigBlock = await this.createDefaultUiConfig()
         currentConfig.platforms.push(uiConfigBlock)
         saveRequired = true
@@ -812,7 +873,7 @@ export class HomebridgeServiceHelper {
       // Ensure the port is set
       if (this.action !== 'install' && typeof uiConfigBlock.port !== 'number') {
         uiConfigBlock.port = await this.getLastKnownUiPort()
-        this.logger(`Added missing port number to UI config: ${uiConfigBlock.port}.`, 'info')
+        this.logger.log(`Added missing port number to UI config: ${uiConfigBlock.port}.`)
         saveRequired = true
         restartRequired = true
       }
@@ -822,7 +883,7 @@ export class HomebridgeServiceHelper {
         // Correct the port
         if (uiConfigBlock.port !== this.uiPort) {
           uiConfigBlock.port = this.uiPort
-          this.logger(`Homebridge UI port in ${process.env.UIX_CONFIG_PATH} changed to: ${this.uiPort}.`, 'warn')
+          this.logger.warn(`Homebridge UI port in ${process.env.UIX_CONFIG_PATH} changed to: ${this.uiPort}.`)
         }
         // Delete unnecessary config
         delete uiConfigBlock.restart
@@ -834,7 +895,7 @@ export class HomebridgeServiceHelper {
       // Ensure the ui port is defined and is a number
       if (typeof uiConfigBlock.port !== 'number') {
         uiConfigBlock.port = await this.getLastKnownUiPort()
-        this.logger(`Added missing port number to UI config: ${uiConfigBlock.port}.`, 'info')
+        this.logger.log(`Added missing port number to UI config: ${uiConfigBlock.port}.`)
         saveRequired = true
         restartRequired = true
       }
@@ -842,21 +903,21 @@ export class HomebridgeServiceHelper {
       // Check the bridge section exists
       if (!currentConfig.bridge) {
         currentConfig.bridge = await this.generateBridgeConfig()
-        this.logger('Added missing Homebridge bridge section to the config.json.', 'info')
+        this.logger.log('Added missing Homebridge bridge section to the config.json.')
         saveRequired = true
       }
 
       // Ensure port is set in bridge config
       if (!currentConfig.bridge.port) {
         currentConfig.bridge.port = await this.generatePort()
-        this.logger(`Added port to the Homebridge bridge section of the config.json: ${currentConfig.bridge.port}.`, 'info')
+        this.logger.log(`Added port to the Homebridge bridge section of the config.json: ${currentConfig.bridge.port}.`)
         saveRequired = true
       }
 
       // Ensure bridge port is not the same as the UI port
       if ((uiConfigBlock && currentConfig.bridge.port === uiConfigBlock.port) || currentConfig.bridge.port === 8080) {
         currentConfig.bridge.port = await this.generatePort()
-        this.logger(`Bridge port must not be the same as the UI port. Changing bridge port to: ${currentConfig.bridge.port}.`, 'info')
+        this.logger.log(`Bridge port must not be the same as the UI port. Changing bridge port to: ${currentConfig.bridge.port}.`)
         saveRequired = true
       }
 
@@ -864,7 +925,7 @@ export class HomebridgeServiceHelper {
       if (currentConfig.plugins && Array.isArray(currentConfig.plugins)) {
         if (!currentConfig.plugins.includes('homebridge-config-ui-x')) {
           currentConfig.plugins.push('homebridge-config-ui-x')
-          this.logger('Added Homebridge UI to the plugins array in the config.json.', 'info')
+          this.logger.log('Added Homebridge UI to the plugins array in the config.json.')
           saveRequired = true
         }
       }
@@ -874,8 +935,8 @@ export class HomebridgeServiceHelper {
       }
     } catch (e) {
       const backupFile = resolve(this.storagePath, `config.json.invalid.${Date.now().toString()}`)
-      this.logger(`${process.env.UIX_CONFIG_PATH} does not contain valid JSON.`, 'warn')
-      this.logger(`Invalid config.json file has been backed up to ${backupFile}.`, 'warn')
+      this.logger.warn(`${process.env.UIX_CONFIG_PATH} does not contain valid JSON.`)
+      this.logger.warn(`Invalid config.json file has been backed up to ${backupFile}.`)
       await rename(process.env.UIX_CONFIG_PATH, backupFile)
       await this.createDefaultConfig()
       restartRequired = true
@@ -884,7 +945,7 @@ export class HomebridgeServiceHelper {
     // If the port number potentially changed, we need to restart here when running the
     // Raspbian image so the nginx config will be updated
     if (restartRequired && this.action === 'run' && await this.isRaspbianImage()) {
-      this.logger('Restarting process after port number update.', 'info')
+      this.logger.log('Restarting process after port number update.')
       process.exit(1)
     }
   }
@@ -1078,7 +1139,7 @@ export class HomebridgeServiceHelper {
       }
 
       // Kill the stale Homebridge process
-      this.logger(`Found stale Homebridge process running on port: ${currentConfig.bridge.port}, with PID: ${pid}, killing...`)
+      this.logger.log(`Found stale Homebridge process running on port: ${currentConfig.bridge.port}, with PID: ${pid}, killing...`)
       process.kill(pid, 'SIGKILL')
     } catch (e) {
       // Do nothing
@@ -1090,7 +1151,7 @@ export class HomebridgeServiceHelper {
    */
   private async tailLogs() {
     if (!existsSync(this.logPath)) {
-      this.logger(`Log file does not exist at expected location: ${this.logPath}.`, 'fail')
+      this.logger.error(`Log file does not exist at expected location: ${this.logPath}.`)
       process.exit(1)
     }
 
@@ -1123,7 +1184,7 @@ export class HomebridgeServiceHelper {
   private async viewLogs() {
     this.installer.viewLogs()
     if (!existsSync(this.logPath)) {
-      this.logger(`Log file does not exist at expected location: ${this.logPath}.`, 'fail')
+      this.logger.error(`Log file does not exist at expected location: ${this.logPath}.`)
       process.exit(1)
     }
 
@@ -1200,7 +1261,7 @@ export class HomebridgeServiceHelper {
         }
       }
     } catch (e) {
-      this.logger(`Failed to load startup options as ${e.message}.`)
+      this.logger.log(`Failed to load startup options as ${e.message}.`)
     }
   }
 
@@ -1226,7 +1287,7 @@ export class HomebridgeServiceHelper {
 
     // Check response is valid array
     if (!Array.isArray(versionList)) {
-      this.logger('Failed to check for Node.js updates.', 'fail')
+      this.logger.error('Failed to check for Node.js updates.')
       return { update: false }
     }
 
@@ -1238,22 +1299,22 @@ export class HomebridgeServiceHelper {
       if (wantedVersion) {
         // Check the requested version is greater than v22.12.0
         if (!gte(wantedVersion.version, '22.12.0')) {
-          this.logger('Refusing to install Node.js version lower than v22.12.0.', 'fail')
+          this.logger.error('Refusing to install Node.js version lower than v22.12.0.')
           return { update: false }
         }
-        this.logger(`Installing Node.js ${wantedVersion.version} over ${process.version}...`, 'info')
+        this.logger.log(`Installing Node.js ${wantedVersion.version} over ${process.version}...`)
         return this.installer.updateNodejs({
           target: wantedVersion.version,
           rebuild: wantedVersion.modules !== process.versions.modules,
         })
       } else {
-        this.logger(`v${requestedVersion} is not a valid Node.js version.`, 'info')
+        this.logger.log(`v${requestedVersion} is not a valid Node.js version.`)
         return { update: false }
       }
     }
 
     if (gt(currentLts.version, process.version)) {
-      this.logger(`Updating Node.js from ${process.version} to ${currentLts.version}...`, 'info')
+      this.logger.log(`Updating Node.js from ${process.version} to ${currentLts.version}...`)
       return this.installer.updateNodejs({
         target: currentLts.version,
         rebuild: currentLts.modules !== process.versions.modules,
@@ -1264,14 +1325,14 @@ export class HomebridgeServiceHelper {
     const latestVersion = versionList.filter(x => parse(x.version).major === currentMajor)[0]
 
     if (gt(latestVersion.version, process.version)) {
-      this.logger(`Updating Node.js from ${process.version} to ${latestVersion.version}...`, 'info')
+      this.logger.log(`Updating Node.js from ${process.version} to ${latestVersion.version}...`)
       return this.installer.updateNodejs({
         target: latestVersion.version,
         rebuild: latestVersion.modules !== process.versions.modules,
       })
     }
 
-    this.logger(`Node.js ${process.version} already up-to-date.`)
+    this.logger.log(`Node.js ${process.version} already up-to-date.`)
 
     return { update: false }
   }
@@ -1343,18 +1404,18 @@ export class HomebridgeServiceHelper {
    * Check the current status of the Homebridge UI by calling its API
    */
   private async checkStatus() {
-    this.logger(`Testing hb-service is running on port ${this.uiPort}...`)
+    this.logger.log(`Testing hb-service is running on port ${this.uiPort}...`)
 
     try {
       const res = await axios.get(`http://localhost:${this.uiPort}/api`)
       if (res.data === 'Hello World!') {
-        this.logger('Homebridge UI running.', 'succeed')
+        this.logger.success('Homebridge UI running.')
       } else {
-        this.logger('Unexpected response.', 'fail')
+        this.logger.error('Unexpected response.')
         process.exit(1)
       }
     } catch (e) {
-      this.logger('Homebridge UI not running.', 'fail')
+      this.logger.error('Homebridge UI not running.')
       process.exit(1)
     }
   }
@@ -1367,7 +1428,7 @@ export class HomebridgeServiceHelper {
     const m = RE_SCOPED.exec(input) || RE_NON_SCOPED.exec(input)
 
     if (!m) {
-      this.logger('Invalid plugin name.', 'fail')
+      this.logger.error('Invalid plugin name.')
       process.exit(1)
     }
 
@@ -1383,12 +1444,12 @@ export class HomebridgeServiceHelper {
    */
   private async npmPluginManagement(args: any[]) {
     if (!this.enableHbServicePluginManagement) {
-      this.logger('Plugin management is not supported on your platform using hb-service.', 'fail')
+      this.logger.error('Plugin management is not supported on your platform using hb-service.')
       process.exit(1)
     }
 
     if (args.length === 1) {
-      this.logger('Plugin name required.', 'fail')
+      this.logger.error('Plugin name required.')
       process.exit(1)
     }
 
@@ -1396,12 +1457,12 @@ export class HomebridgeServiceHelper {
     const target = this.parseNpmPackageString(args.at(-1))
 
     if (!target.name) {
-      this.logger('Invalid plugin name.', 'fail')
+      this.logger.error('Invalid plugin name.')
       process.exit(1)
     }
 
     if (!RE_PLUGIN_NAME.test(target.name)) {
-      this.logger('Invalid plugin name.', 'fail')
+      this.logger.error('Invalid plugin name.')
       process.exit(1)
     }
 
@@ -1412,19 +1473,19 @@ export class HomebridgeServiceHelper {
     // dots, dashes, semver operators) before going near a spawn.
     const RE_NPM_VERSION_OR_TAG = /^[\w.\-^~>=<*|+]+$/
     if (!RE_NPM_VERSION_OR_TAG.test(target.version)) {
-      this.logger(`Invalid plugin version "${target.version}".`, 'fail')
+      this.logger.error(`Invalid plugin version "${target.version}".`)
       process.exit(1)
     }
 
     const cwd = dirname(process.env.UIX_CUSTOM_PLUGIN_PATH)
 
     if (!await pathExists(cwd)) {
-      this.logger(`Path does not exist: ${cwd}.`, 'fail')
+      this.logger.error(`Path does not exist: ${cwd}.`)
     }
 
     const npmArgs = ['--prefix', cwd, action, action === 'add' ? `${target.name}@${target.version}` : target.name]
 
-    this.logger(`CMD: npm ${npmArgs.join(' ')}`, 'info')
+    this.logger.log(`CMD: npm ${npmArgs.join(' ')}`)
 
     try {
       // execFileSync (argv form, no shell) keeps target.name and
@@ -1434,9 +1495,9 @@ export class HomebridgeServiceHelper {
         cwd,
         stdio: 'inherit',
       })
-      this.logger(`Installed ${target.name}@${target.version}.`, 'succeed')
+      this.logger.success(`Installed ${target.name}@${target.version}.`)
     } catch (e) {
-      this.logger(`Plugin installation failed as ${e.message}.`, 'fail')
+      this.logger.error(`Plugin installation failed as ${e.message}.`)
     }
   }
 }

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -47,10 +47,12 @@ const __dirname = dirname(__filename)
 type Action = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'rebuild' | 'run' | 'add' | 'remove' | 'logs' | 'view' | 'update-node' | 'update-homebridge' | 'before-start' | 'status'
 
 class Logger {
+  // Read `action` and `logFile` from the service helper at write time —
+  // `logFile` is not assigned until `startLog()` runs, which happens after
+  // the first log calls in the `run` path, so it must not be snapshotted here.
   constructor(
-    private readonly action: Action,
-    private readonly logFile: WriteStream | NodeJS.WriteStream,
-  ) { }
+    private readonly hbService: HomebridgeServiceHelper,
+  ) {}
 
   log(msg: string) {
     this._log(msg, 'info')
@@ -77,12 +79,12 @@ class Logger {
   }
 
   private _log(msg: string, level: 'info' | 'success' | 'error' | 'warn' | 'debug' | 'verbose') {
-    if (this.action === 'run') {
+    if (this.hbService.action === 'run') {
       msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
         + `\x1B[36m[HB Supervisor]\x1B[0m [${level.toUpperCase()}] ${msg}`
 
-      if (this.logFile) {
-        this.logFile.write(`${msg}\n`)
+      if (this.hbService.logFile) {
+        this.hbService.logFile.write(`${msg}\n`)
       } else {
         console.log(msg)
       }
@@ -121,7 +123,7 @@ export class HomebridgeServiceHelper {
   public asUser: string
   public addGroup: string
   public _logger: Logger
-  private logFile: WriteStream | NodeJS.WriteStream
+  public logFile: WriteStream | NodeJS.WriteStream
   private homebridgeModulePath: string
   private homebridgePackage: { version: string, bin: { homebridge: string } }
   private homebridgeBinary: string
@@ -151,7 +153,7 @@ export class HomebridgeServiceHelper {
 
   get logger(): Logger {
     if (!this._logger) {
-      this._logger = new Logger(this.action, this.logFile)
+      this._logger = new Logger(this)
     }
     return this._logger
   }

--- a/src/bin/logger.ts
+++ b/src/bin/logger.ts
@@ -1,0 +1,81 @@
+/* global NodeJS */
+/* eslint-disable no-console */
+
+import type { WriteStream } from 'node:fs'
+
+import ora from 'ora'
+
+/**
+ * The parts of HomebridgeServiceHelper the logger reads. Kept as an interface
+ * so the logger can be tested without importing (and so executing) hb-service.
+ */
+export interface LoggerHost {
+  action: string
+  logFile?: WriteStream | NodeJS.WriteStream
+}
+
+export class Logger {
+  // Read `action` and `logFile` from the service helper at write time —
+  // `logFile` is not assigned until `startLog()` runs, which happens after
+  // the first log calls in the `run` path, so it must not be snapshotted here.
+  constructor(
+    private readonly hbService: LoggerHost,
+  ) {}
+
+  log(msg: string) {
+    this._log(msg, 'info')
+  }
+
+  success(msg: string) {
+    this._log(msg, 'success')
+  }
+
+  error(msg: string) {
+    this._log(msg, 'error')
+  }
+
+  warn(msg: string) {
+    this._log(msg, 'warn')
+  }
+
+  debug(msg: string) {
+    this._log(msg, 'debug')
+  }
+
+  verbose(msg: string) {
+    this._log(msg, 'verbose')
+  }
+
+  private _log(msg: string, level: 'info' | 'success' | 'error' | 'warn' | 'debug' | 'verbose') {
+    if (this.hbService.action === 'run') {
+      msg = `\x1B[37m[${new Date().toLocaleString()}]\x1B[0m `
+        + `\x1B[36m[HB Supervisor]\x1B[0m [${level.toUpperCase()}] ${msg}`
+
+      if (this.hbService.logFile) {
+        this.hbService.logFile.write(`${msg}\n`)
+      } else {
+        console.log(msg)
+      }
+    } else {
+      let oraLevel: 'info' | 'succeed' | 'fail' | 'warn'
+      switch (level) {
+        case 'info':
+        case 'debug':
+        case 'verbose':
+          oraLevel = 'info'
+          break
+        case 'success':
+          oraLevel = 'succeed'
+          break
+        case 'error':
+          oraLevel = 'fail'
+          break
+        case 'warn':
+          oraLevel = 'warn'
+          break
+      }
+
+      ora()[oraLevel](msg)
+    }
+  }
+}

--- a/src/bin/platforms/darwin.ts
+++ b/src/bin/platforms/darwin.ts
@@ -217,7 +217,7 @@ export class DarwinInstaller extends BasePlatform {
     // `--user 'foo"; rm -rf /; echo "'` execute as root at install-time.
     if (!RE_OS_USERNAME.test(this.user)) {
       this.hbService.logger.warn(
-        `WARNING: Refusing to resolve home directory — invalid username "${this.user}".`
+        `WARNING: Refusing to resolve home directory — invalid username "${this.user}".`,
       )
       return homedir()
     }

--- a/src/bin/platforms/darwin.ts
+++ b/src/bin/platforms/darwin.ts
@@ -41,7 +41,7 @@ export class DarwinInstaller extends BasePlatform {
       await this.hbService.printPostInstallInstructions()
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -54,14 +54,14 @@ export class DarwinInstaller extends BasePlatform {
 
     try {
       if (existsSync(this.plistPath)) {
-        this.hbService.logger(`Removed ${this.hbService.serviceName} Service`, 'succeed')
+        this.hbService.logger.success(`Removed ${this.hbService.serviceName} Service`)
         unlinkSync(this.plistPath)
       } else {
-        this.hbService.logger(`Could not find installed ${this.hbService.serviceName} Service.`, 'fail')
+        this.hbService.logger.error(`Could not find installed ${this.hbService.serviceName} Service.`)
       }
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -71,11 +71,11 @@ export class DarwinInstaller extends BasePlatform {
   public async start() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Starting ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Starting ${this.hbService.serviceName} Service...`)
       execFileSync('launchctl', ['load', '-w', this.plistPath])
-      this.hbService.logger(`${this.hbService.serviceName} Started`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Started`)
     } catch (e) {
-      this.hbService.logger(`Failed to start ${this.hbService.serviceName}`, 'fail')
+      this.hbService.logger.error(`Failed to start ${this.hbService.serviceName}`)
     }
   }
 
@@ -85,11 +85,11 @@ export class DarwinInstaller extends BasePlatform {
   public async stop() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Stopping ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Stopping ${this.hbService.serviceName} Service...`)
       execFileSync('launchctl', ['unload', '-w', this.plistPath])
-      this.hbService.logger(`${this.hbService.serviceName} Stopped`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Stopped`)
     } catch (e) {
-      this.hbService.logger(`Failed to stop ${this.hbService.serviceName}`, 'fail')
+      this.hbService.logger.error(`Failed to stop ${this.hbService.serviceName}`)
     }
   }
 
@@ -130,7 +130,7 @@ export class DarwinInstaller extends BasePlatform {
         cwd: process.env.UIX_BASE_PATH,
         stdio: 'inherit',
       })
-      this.hbService.logger(`Rebuilt homebridge-config-ui-x for Node.js ${targetNodeVersion}.`, 'succeed')
+      this.hbService.logger.success(`Rebuilt homebridge-config-ui-x for Node.js ${targetNodeVersion}.`)
 
       if (all === true) {
         // Rebuild all modules
@@ -139,16 +139,16 @@ export class DarwinInstaller extends BasePlatform {
             cwd: npmGlobalPath,
             stdio: 'inherit',
           })
-          this.hbService.logger(`Rebuilt plugins in ${npmGlobalPath} for Node.js ${targetNodeVersion}.`, 'succeed')
+          this.hbService.logger.success(`Rebuilt plugins in ${npmGlobalPath} for Node.js ${targetNodeVersion}.`)
         } catch (e) {
-          this.hbService.logger('Could not rebuild all modules - check Homebridge logs.', 'warn')
+          this.hbService.logger.warn('Could not rebuild all modules - check Homebridge logs.')
         }
       }
 
       await this.setNpmPermissions(npmGlobalPath)
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -187,13 +187,13 @@ export class DarwinInstaller extends BasePlatform {
    */
   private checkForRoot() {
     if (process.getuid() !== 0) {
-      this.hbService.logger('ERROR: This command must be executed using sudo on macOS', 'fail')
-      this.hbService.logger(`sudo hb-service ${this.hbService.action}`, 'fail')
+      this.hbService.logger.error('ERROR: This command must be executed using sudo on macOS')
+      this.hbService.logger.error(`sudo hb-service ${this.hbService.action}`)
       process.exit(1)
     }
     if (!process.env.SUDO_USER && !this.hbService.asUser) {
-      this.hbService.logger('ERROR: Could not detect user. Pass in the user you want to run Homebridge as using the --user flag eg.', 'fail')
-      this.hbService.logger(`sudo hb-service ${this.hbService.action} --user your-user`, 'fail')
+      this.hbService.logger.error('ERROR: Could not detect user. Pass in the user you want to run Homebridge as using the --user flag eg.')
+      this.hbService.logger.error(`sudo hb-service ${this.hbService.action} --user your-user`)
       process.exit(1)
     }
     this.user = this.hbService.asUser || process.env.SUDO_USER
@@ -216,9 +216,8 @@ export class DarwinInstaller extends BasePlatform {
     // Routing the value through a shell here would let a crafted
     // `--user 'foo"; rm -rf /; echo "'` execute as root at install-time.
     if (!RE_OS_USERNAME.test(this.user)) {
-      this.hbService.logger(
-        `WARNING: Refusing to resolve home directory — invalid username "${this.user}".`,
-        'warn',
+      this.hbService.logger.warn(
+        `WARNING: Refusing to resolve home directory — invalid username "${this.user}".`
       )
       return homedir()
     }
@@ -243,18 +242,18 @@ export class DarwinInstaller extends BasePlatform {
     this.checkForRoot()
 
     if (!['x64', 'arm64'].includes(process.arch)) {
-      this.hbService.logger(`Architecture not supported: ${process.arch}.`, 'fail')
+      this.hbService.logger.error(`Architecture not supported: ${process.arch}.`)
       process.exit(1)
     }
 
     if (process.arch === 'arm64' && lt(job.target, '18.0.0')) {
-      this.hbService.logger('macOS M1 / arm64 support is only available from Node.js v18 or later', 'fail')
+      this.hbService.logger.error('macOS M1 / arm64 support is only available from Node.js v18 or later')
       process.exit(1)
     }
 
     // Node.js 18+ requires macOS 10.15 or later, which starts with Darwin 19.0.0
     if (lt(release(), '19.0.0') && gte(job.target, '18.0.0')) {
-      this.hbService.logger('macOS Catalina 10.15 or later is required to install Node.js v18 or later', 'fail')
+      this.hbService.logger.error('macOS Catalina 10.15 or later is required to install Node.js v18 or later')
       process.exit(1)
     }
 
@@ -263,11 +262,11 @@ export class DarwinInstaller extends BasePlatform {
 
     // Only allow updates when installed using the official Node.js installer / Homebridge package
     if (targetPath !== '/usr/local' && !targetPath.startsWith('/Library/Application Support/Homebridge/node-')) {
-      this.hbService.logger(`Cannot update Node.js on your system. Non-standard installation path detected: ${targetPath}`, 'fail')
+      this.hbService.logger.error(`Cannot update Node.js on your system. Non-standard installation path detected: ${targetPath}`)
       process.exit(1)
     }
 
-    this.hbService.logger(`Target: ${targetPath}`)
+    this.hbService.logger.log(`Target: ${targetPath}`)
 
     try {
       const archivePath = await this.hbService.downloadNodejs(downloadUrl)
@@ -296,10 +295,10 @@ export class DarwinInstaller extends BasePlatform {
       if (await pathExists(this.plistPath)) {
         await this.restart()
       } else {
-        this.hbService.logger('Please restart Homebridge for the changes to take effect.', 'warn')
+        this.hbService.logger.warn('Please restart Homebridge for the changes to take effect.')
       }
     } catch (e) {
-      this.hbService.logger(`Failed to update Node.js: ${e.message}`, 'fail')
+      this.hbService.logger.error(`Failed to update Node.js: ${e.message}`)
       process.exit(1)
     }
   }
@@ -342,8 +341,8 @@ export class DarwinInstaller extends BasePlatform {
       execSync(`chown -R ${this.user}:admin "${npmGlobalPath}"`)
       execSync(`chown -R ${this.user}:admin "$(dirname $(which npm))"`)
     } catch (e) {
-      this.hbService.logger(`ERROR: User "${this.user}" does not have write access to the global npm modules path.`, 'fail')
-      this.hbService.logger('You can fix this issue by running the following commands:', 'fail')
+      this.hbService.logger.error(`ERROR: User "${this.user}" does not have write access to the global npm modules path.`)
+      this.hbService.logger.error('You can fix this issue by running the following commands:')
 
       /* eslint-disable no-console */
       console.log('')
@@ -352,7 +351,7 @@ export class DarwinInstaller extends BasePlatform {
       console.log('')
       /* eslint-enable no-console */
 
-      this.hbService.logger('Once you have done this run the hb-service install command again to complete your installation.', 'fail')
+      this.hbService.logger.error('Once you have done this run the hb-service install command again to complete your installation.')
       process.exit(1)
     }
   }

--- a/src/bin/platforms/freebsd.ts
+++ b/src/bin/platforms/freebsd.ts
@@ -38,7 +38,7 @@ export class FreeBSDInstaller extends BasePlatform {
       await this.hbService.printPostInstallInstructions()
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -54,14 +54,14 @@ export class FreeBSDInstaller extends BasePlatform {
 
     try {
       if (existsSync(this.rcServicePath)) {
-        this.hbService.logger(`Removed ${this.rcServiceName} Service`, 'succeed')
+        this.hbService.logger.success(`Removed ${this.rcServiceName} Service`)
         unlinkSync(this.rcServicePath)
       } else {
-        this.hbService.logger(`Could not find installed ${this.rcServiceName} Service.`, 'fail')
+        this.hbService.logger.error(`Could not find installed ${this.rcServiceName} Service.`)
       }
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -71,11 +71,11 @@ export class FreeBSDInstaller extends BasePlatform {
   public async start() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Starting ${this.rcServiceName} Service...`)
+      this.hbService.logger.log(`Starting ${this.rcServiceName} Service...`)
       execSync(`service ${this.rcServiceName} start`, { stdio: 'inherit' })
-      this.hbService.logger(`${this.rcServiceName} Started`, 'succeed')
+      this.hbService.logger.success(`${this.rcServiceName} Started`)
     } catch (e) {
-      this.hbService.logger(`Failed to start ${this.rcServiceName}`, 'fail')
+      this.hbService.logger.error(`Failed to start ${this.rcServiceName}`)
     }
   }
 
@@ -85,11 +85,11 @@ export class FreeBSDInstaller extends BasePlatform {
   public async stop() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Stopping ${this.rcServiceName} Service...`)
+      this.hbService.logger.log(`Stopping ${this.rcServiceName} Service...`)
       execSync(`service ${this.rcServiceName} stop`, { stdio: 'inherit' })
-      this.hbService.logger(`${this.rcServiceName} Stopped`, 'succeed')
+      this.hbService.logger.success(`${this.rcServiceName} Stopped`)
     } catch (e) {
-      this.hbService.logger(`Failed to stop ${this.rcServiceName}`, 'fail')
+      this.hbService.logger.error(`Failed to stop ${this.rcServiceName}`)
     }
   }
 
@@ -99,11 +99,11 @@ export class FreeBSDInstaller extends BasePlatform {
   public async restart() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Restarting ${this.rcServiceName} Service...`)
+      this.hbService.logger.log(`Restarting ${this.rcServiceName} Service...`)
       execSync(`service ${this.rcServiceName} restart`, { stdio: 'inherit' })
-      this.hbService.logger(`${this.rcServiceName} Restarted`, 'succeed')
+      this.hbService.logger.success(`${this.rcServiceName} Restarted`)
     } catch (e) {
-      this.hbService.logger(`Failed to restart ${this.rcServiceName}`, 'fail')
+      this.hbService.logger.error(`Failed to restart ${this.rcServiceName}`)
     }
   }
 
@@ -135,14 +135,14 @@ export class FreeBSDInstaller extends BasePlatform {
             stdio: 'inherit',
           })
         } catch (e) {
-          this.hbService.logger('Could not rebuild all modules - check Homebridge logs.', 'warn')
+          this.hbService.logger.warn('Could not rebuild all modules - check Homebridge logs.')
         }
       }
 
-      this.hbService.logger(`Rebuilt modules in ${process.env.UIX_BASE_PATH} for Node.js ${targetNodeVersion}.`, 'succeed')
+      this.hbService.logger.success(`Rebuilt modules in ${process.env.UIX_BASE_PATH} for Node.js ${targetNodeVersion}.`)
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -183,7 +183,7 @@ export class FreeBSDInstaller extends BasePlatform {
     try {
       execSync(`sysrc ${this.rcServiceName}_enable="YES" 2> /dev/null`)
     } catch (e) {
-      this.hbService.logger(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"YES\"`, 'warn')
+      this.hbService.logger.warn(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"YES\"`)
     }
   }
 
@@ -194,7 +194,7 @@ export class FreeBSDInstaller extends BasePlatform {
     try {
       execSync(`sysrc ${this.rcServiceName}_enable="NO" 2> /dev/null`)
     } catch (e) {
-      this.hbService.logger(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"NO\"`, 'warn')
+      this.hbService.logger.warn(`WARNING: failed to run "sysrc ${this.rcServiceName}_enable=\"NO\"`)
     }
   }
 
@@ -203,13 +203,13 @@ export class FreeBSDInstaller extends BasePlatform {
    */
   private checkForRoot() {
     if (process.getuid() !== 0) {
-      this.hbService.logger('ERROR: This command must be executed using sudo on FreeBSD', 'fail')
-      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action}`, 'fail')
+      this.hbService.logger.error('ERROR: This command must be executed using sudo on FreeBSD')
+      this.hbService.logger.error(`EXAMPLE: sudo hb-service ${this.hbService.action}`)
       process.exit(1)
     }
     if (this.hbService.action === 'install' && !process.env.SUDO_USER && !this.hbService.asUser) {
-      this.hbService.logger('ERROR: Could not detect user. Pass in the user you want to run Homebridge as using the --user flag eg.', 'fail')
-      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action} --user your-user`, 'fail')
+      this.hbService.logger.error('ERROR: Could not detect user. Pass in the user you want to run Homebridge as using the --user flag eg.')
+      this.hbService.logger.error(`EXAMPLE: sudo hb-service ${this.hbService.action} --user your-user`)
       process.exit(1)
     }
   }
@@ -224,7 +224,7 @@ export class FreeBSDInstaller extends BasePlatform {
     } catch (e) {
       // If not create the user
       execSync(`pw useradd -q -n ${this.hbService.asUser} -s /usr/sbin/nologin 2> /dev/null`)
-      this.hbService.logger(`Created service user: ${this.hbService.asUser}`, 'info')
+      this.hbService.logger.log(`Created service user: ${this.hbService.asUser}`)
     }
   }
 
@@ -237,9 +237,8 @@ export class FreeBSDInstaller extends BasePlatform {
       // Refuse to interpolate an unvalidated username into the sudoers line —
       // a crafted `--user` could otherwise inject `, /bin/sh` and grant NOPASSWD.
       if (!RE_OS_USERNAME.test(this.hbService.asUser)) {
-        this.hbService.logger(
+        this.hbService.logger.warn(
           `WARNING: Refusing to write /usr/local/etc/sudoers entry — invalid username "${this.hbService.asUser}".`,
-          'warn',
         )
         return
       }
@@ -256,7 +255,7 @@ export class FreeBSDInstaller extends BasePlatform {
       // Grant the user restricted sudo privileges to /sbin/shutdown
       execSync(`echo '${sudoersEntry}' | sudo EDITOR='tee -a' visudo`)
     } catch (e) {
-      this.hbService.logger('WARNING: Failed to setup /etc/sudoers, you may not be able to shutdown/restart your server from the Homebridge UI.', 'warn')
+      this.hbService.logger.warn('WARNING: Failed to setup /etc/sudoers, you may not be able to shutdown/restart your server from the Homebridge UI.')
     }
   }
 
@@ -264,7 +263,7 @@ export class FreeBSDInstaller extends BasePlatform {
    * Update Node.js
    */
   public async updateNodejs(job: { target: string, rebuild: boolean }) {
-    this.hbService.logger('Update Node.js using pkg manually.', 'fail')
+    this.hbService.logger.error('Update Node.js using pkg manually.')
     process.exit(1)
   }
 

--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -625,7 +625,7 @@ export class LinuxInstaller extends BasePlatform {
       // (e.g. `foo, /bin/sh`) and grant NOPASSWD to arbitrary binaries.
       if (!RE_OS_USERNAME.test(this.hbService.asUser)) {
         this.hbService.logger.warn(
-          `WARNING: Refusing to write /etc/sudoers entry — invalid username "${this.hbService.asUser}".`
+          `WARNING: Refusing to write /etc/sudoers entry — invalid username "${this.hbService.asUser}".`,
         )
         return
       }

--- a/src/bin/platforms/linux.ts
+++ b/src/bin/platforms/linux.ts
@@ -53,7 +53,7 @@ export class LinuxInstaller extends BasePlatform {
       await this.hbService.printPostInstallInstructions()
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -75,10 +75,10 @@ export class LinuxInstaller extends BasePlatform {
       // Reload services
       await this.reloadSystemd()
 
-      this.hbService.logger(`Removed ${this.hbService.serviceName} Service`, 'succeed')
+      this.hbService.logger.success(`Removed ${this.hbService.serviceName} Service`)
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -92,7 +92,7 @@ export class LinuxInstaller extends BasePlatform {
       // eslint-disable-next-line no-console
       console.log(ret)
     } catch (e) {
-      this.hbService.logger(`Failed to start ${this.hbService.serviceName} - ${e}`, 'fail')
+      this.hbService.logger.error(`Failed to start ${this.hbService.serviceName} - ${e}`)
     }
   }
 
@@ -103,11 +103,11 @@ export class LinuxInstaller extends BasePlatform {
     this.checkForRoot()
     this.fixPermissions()
     try {
-      this.hbService.logger(`Starting ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Starting ${this.hbService.serviceName} Service...`)
       execSync(`systemctl start ${this.systemdServiceName}`)
       execSync(`systemctl status ${this.systemdServiceName} --no-pager`)
     } catch (e) {
-      this.hbService.logger(`Failed to start ${this.hbService.serviceName} - ${e}`, 'fail')
+      this.hbService.logger.error(`Failed to start ${this.hbService.serviceName} - ${e}`)
       process.exit(1)
     }
   }
@@ -118,11 +118,11 @@ export class LinuxInstaller extends BasePlatform {
   public async stop() {
     this.checkForRoot()
     try {
-      this.hbService.logger(`Stopping ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Stopping ${this.hbService.serviceName} Service...`)
       execSync(`systemctl stop ${this.systemdServiceName}`)
-      this.hbService.logger(`${this.hbService.serviceName} Stopped`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Stopped`)
     } catch (e) {
-      this.hbService.logger(`Failed to stop ${this.systemdServiceName} - ${e}`, 'fail')
+      this.hbService.logger.error(`Failed to stop ${this.systemdServiceName} - ${e}`)
     }
   }
 
@@ -133,12 +133,12 @@ export class LinuxInstaller extends BasePlatform {
     this.checkForRoot()
     this.fixPermissions()
     try {
-      this.hbService.logger(`Restarting ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Restarting ${this.hbService.serviceName} Service...`)
       execSync(`systemctl restart ${this.systemdServiceName}`)
       execSync(`systemctl status ${this.systemdServiceName} --no-pager`)
-      this.hbService.logger(`${this.hbService.serviceName} Restarted`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Restarted`)
     } catch (e) {
-      this.hbService.logger(`Failed to restart ${this.hbService.serviceName} - ${e}`, 'fail')
+      this.hbService.logger.error(`Failed to restart ${this.hbService.serviceName} - ${e}`)
     }
   }
 
@@ -200,7 +200,7 @@ export class LinuxInstaller extends BasePlatform {
         cwd: process.env.UIX_BASE_PATH,
         stdio: 'inherit',
       })
-      this.hbService.logger(`Rebuilt homebridge-config-ui-x for Node.js ${targetNodeVersion}.`, 'succeed')
+      this.hbService.logger.success(`Rebuilt homebridge-config-ui-x for Node.js ${targetNodeVersion}.`)
 
       if (all === true) {
         // Rebuild all global node_modules
@@ -209,14 +209,14 @@ export class LinuxInstaller extends BasePlatform {
             cwd: npmGlobalPath,
             stdio: 'inherit',
           })
-          this.hbService.logger(`Rebuilt plugins in ${npmGlobalPath} for Node.js ${targetNodeVersion}.`, 'succeed')
+          this.hbService.logger.success(`Rebuilt plugins in ${npmGlobalPath} for Node.js ${targetNodeVersion}.`)
         } catch (e) {
-          this.hbService.logger('Could not rebuild all plugins - check logs.', 'warn')
+          this.hbService.logger.warn('Could not rebuild all plugins - check logs.')
         }
       }
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -268,8 +268,8 @@ export class LinuxInstaller extends BasePlatform {
     // Check if trying to install Node.js 24 on unsupported architecture
     if (gte(job.target, '24.0.0')) {
       if (!isNodeV24SupportedArchitecture()) {
-        this.hbService.logger(`Node.js ${job.target} is not supported on ${process.arch} architecture.`, 'fail')
-        this.hbService.logger('Node.js v24 requires a 64-bit architecture. Please use Node.js v22 instead.', 'fail')
+        this.hbService.logger.error(`Node.js ${job.target} is not supported on ${process.arch} architecture.`)
+        this.hbService.logger.error('Node.js v24 requires a 64-bit architecture. Please use Node.js v22 instead.')
         process.exit(1)
       }
     }
@@ -278,7 +278,7 @@ export class LinuxInstaller extends BasePlatform {
     const targetPath = dirname(dirname(process.execPath))
 
     if (targetPath !== '/usr' && targetPath !== '/usr/local' && targetPath !== '/opt/homebridge' && !targetPath.endsWith('/@appstore/homebridge/app')) {
-      this.hbService.logger(`Cannot update Node.js on your system. Non-standard installation path detected: ${targetPath}`, 'fail')
+      this.hbService.logger.error(`Cannot update Node.js on your system. Non-standard installation path detected: ${targetPath}`)
       process.exit(1)
     }
 
@@ -292,7 +292,7 @@ export class LinuxInstaller extends BasePlatform {
 
     // Rebuild node modules if required
     if (job.rebuild) {
-      this.hbService.logger(`Rebuilding for Node.js ${job.target}...`)
+      this.hbService.logger.log(`Rebuilding for Node.js ${job.target}...`)
       await this.rebuild(true)
     }
 
@@ -300,7 +300,7 @@ export class LinuxInstaller extends BasePlatform {
     if (await pathExists(this.systemdServicePath)) {
       await this.restart()
     } else {
-      this.hbService.logger('Please restart Homebridge for the changes to take effect.', 'warn')
+      this.hbService.logger.warn('Please restart Homebridge for the changes to take effect.')
     }
   }
 
@@ -309,7 +309,7 @@ export class LinuxInstaller extends BasePlatform {
    */
   public async updateHomebridgePackage() {
     if (process.env.HOMEBRIDGE_APT_PACKAGE !== '1') {
-      this.hbService.logger('ERROR: This command is only available for apt package installs.', 'fail')
+      this.hbService.logger.error('ERROR: This command is only available for apt package installs.')
       process.exit(1)
     }
 
@@ -324,9 +324,9 @@ export class LinuxInstaller extends BasePlatform {
         stdio: 'inherit',
       })
 
-      this.hbService.logger('Homebridge apt package update complete.', 'succeed')
+      this.hbService.logger.success('Homebridge apt package update complete.')
     } catch (e) {
-      this.hbService.logger(`Failed to update Homebridge apt package: ${e.message}`, 'fail')
+      this.hbService.logger.error(`Failed to update Homebridge apt package: ${e.message}`)
       process.exit(1)
     }
   }
@@ -352,18 +352,18 @@ export class LinuxInstaller extends BasePlatform {
   private async glibcVersionCheck(target: string) {
     const glibcVersion = Number.parseFloat(execSync('getconf GNU_LIBC_VERSION 2>/dev/null').toString().split('glibc')[1].trim())
     if (glibcVersion < 2.23) {
-      this.hbService.logger('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
-        + `Wanted: >=2.23. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`, 'fail')
+      this.hbService.logger.error('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
+        + `Wanted: >=2.23. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`)
       process.exit(1)
     }
     if (gte(target, '18.0.0') && glibcVersion < 2.28) {
-      this.hbService.logger('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
-        + `Wanted: >=2.28. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`, 'fail')
+      this.hbService.logger.error('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
+        + `Wanted: >=2.28. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`)
       process.exit(1)
     }
     if (gte(target, '20.0.0') && glibcVersion < 2.31) {
-      this.hbService.logger('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
-        + `Wanted: >=2.31. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`, 'fail')
+      this.hbService.logger.error('Your version of Linux does not meet the GLIBC version requirements to use this tool to upgrade Node.js. '
+        + `Wanted: >=2.31. Installed: ${glibcVersion} - see https://homebridge.io/w/JJSun`)
       process.exit(1)
     }
   }
@@ -398,7 +398,7 @@ export class LinuxInstaller extends BasePlatform {
         // Skip glibc version check on Synology DSM
         // We know node > 18 requires glibc > 2.28, while DSM 7 only has 2.27 at the moment
         if (gte(job.target, '18.0.0')) {
-          this.hbService.logger('Cannot update Node.js on your system. Synology DSM 7 does not currently support Node.js 18 or later.', 'fail')
+          this.hbService.logger.error('Cannot update Node.js on your system. Synology DSM 7 does not currently support Node.js 18 or later.')
           process.exit(1)
         }
       } else {
@@ -407,10 +407,10 @@ export class LinuxInstaller extends BasePlatform {
     } catch (e) {
       const os = await osInfo()
       if (os.distro === 'Alpine Linux') {
-        this.hbService.logger('Updating Node.js on Alpine Linux / Docker is not supported by this command.', 'fail')
-        this.hbService.logger('To update Node.js you should pull down the latest version of the homebridge/homebridge Docker image.', 'fail')
+        this.hbService.logger.error('Updating Node.js on Alpine Linux / Docker is not supported by this command.')
+        this.hbService.logger.error('To update Node.js you should pull down the latest version of the homebridge/homebridge Docker image.')
       } else {
-        this.hbService.logger('Updating Node.js using this tool is not supported on your version of Linux.')
+        this.hbService.logger.log('Updating Node.js using this tool is not supported on your version of Linux.')
       }
       process.exit(1)
     }
@@ -438,11 +438,11 @@ export class LinuxInstaller extends BasePlatform {
         downloadUrl = `https://unofficial-builds.nodejs.org/download/release/${job.target}/node-${job.target}-linux-armv6l.tar.gz`
         break
       default:
-        this.hbService.logger(`Architecture not supported: ${process.arch}.`, 'fail')
+        this.hbService.logger.error(`Architecture not supported: ${process.arch}.`)
         process.exit(1)
     }
 
-    this.hbService.logger(`Target: ${targetPath}`)
+    this.hbService.logger.log(`Target: ${targetPath}`)
 
     try {
       const archivePath = await this.hbService.downloadNodejs(downloadUrl)
@@ -464,7 +464,7 @@ export class LinuxInstaller extends BasePlatform {
       // Clean up
       await remove(archivePath)
     } catch (e) {
-      this.hbService.logger(`Failed to update Node.js: ${e.message}`, 'fail')
+      this.hbService.logger.error(`Failed to update Node.js: ${e.message}`)
       process.exit(1)
     }
   }
@@ -473,7 +473,7 @@ export class LinuxInstaller extends BasePlatform {
    * Update the NodeSource repo and use it to update Node.js
    */
   private async updateNodeFromNodesource(job: { target: string, rebuild: boolean }) {
-    this.hbService.logger('Updating from NodeSource...')
+    this.hbService.logger.log('Updating from NodeSource...')
 
     try {
       await this.glibcVersionCheck(job.target)
@@ -516,7 +516,7 @@ export class LinuxInstaller extends BasePlatform {
         stdio: 'inherit',
       })
     } catch (e) {
-      this.hbService.logger(`Failed to update Node.js: ${e.message}`, 'fail')
+      this.hbService.logger.error(`Failed to update Node.js: ${e.message}`)
       process.exit(1)
     }
   }
@@ -528,7 +528,7 @@ export class LinuxInstaller extends BasePlatform {
     try {
       execSync('systemctl daemon-reload')
     } catch (e) {
-      this.hbService.logger('WARNING: failed to run "systemctl daemon-reload"', 'warn')
+      this.hbService.logger.warn('WARNING: failed to run "systemctl daemon-reload"')
     }
   }
 
@@ -539,7 +539,7 @@ export class LinuxInstaller extends BasePlatform {
     try {
       execSync(`systemctl enable ${this.systemdServiceName} 2> /dev/null`)
     } catch (e) {
-      this.hbService.logger(`WARNING: failed to run "systemctl enable ${this.systemdServiceName}"`, 'warn')
+      this.hbService.logger.warn(`WARNING: failed to run "systemctl enable ${this.systemdServiceName}"`)
     }
   }
 
@@ -550,7 +550,7 @@ export class LinuxInstaller extends BasePlatform {
     try {
       execSync(`systemctl disable ${this.systemdServiceName} 2> /dev/null`)
     } catch (e) {
-      this.hbService.logger(`WARNING: failed to run "systemctl disable ${this.systemdServiceName}"`, 'warn')
+      this.hbService.logger.warn(`WARNING: failed to run "systemctl disable ${this.systemdServiceName}"`)
     }
   }
 
@@ -559,17 +559,17 @@ export class LinuxInstaller extends BasePlatform {
    */
   private checkForRoot() {
     if (this.isPackage()) {
-      this.hbService.logger('ERROR: This command is not available.', 'fail')
+      this.hbService.logger.error('ERROR: This command is not available.')
       process.exit(1)
     }
     if (process.getuid() !== 0) {
-      this.hbService.logger('ERROR: This command must be executed using sudo on Linux', 'fail')
-      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action}`, 'fail')
+      this.hbService.logger.error('ERROR: This command must be executed using sudo on Linux')
+      this.hbService.logger.error(`EXAMPLE: sudo hb-service ${this.hbService.action}`)
       process.exit(1)
     }
     if (this.hbService.action === 'install' && !this.hbService.asUser) {
-      this.hbService.logger('ERROR: User parameter missing. Pass in the user you want to run Homebridge as using the --user flag eg.', 'fail')
-      this.hbService.logger(`EXAMPLE: sudo hb-service ${this.hbService.action} --user your-user`, 'fail')
+      this.hbService.logger.error('ERROR: User parameter missing. Pass in the user you want to run Homebridge as using the --user flag eg.')
+      this.hbService.logger.error(`EXAMPLE: sudo hb-service ${this.hbService.action} --user your-user`)
       process.exit(1)
     }
   }
@@ -579,8 +579,8 @@ export class LinuxInstaller extends BasePlatform {
    */
   private checkIsNotRoot() {
     if (process.getuid() === 0 && !this.hbService.allowRunRoot && process.env.HOMEBRIDGE_CONFIG_UI !== '1') {
-      this.hbService.logger('ERROR: This command must not be executed as root or with sudo', 'fail')
-      this.hbService.logger('ERROR: If you know what you are doing; you can override this by adding --allow-root', 'fail')
+      this.hbService.logger.error('ERROR: This command must not be executed as root or with sudo')
+      this.hbService.logger.error('ERROR: If you know what you are doing; you can override this by adding --allow-root')
       process.exit(1)
     }
   }
@@ -595,10 +595,10 @@ export class LinuxInstaller extends BasePlatform {
     } catch (e) {
       // If not create the user
       execSync(`useradd -m --system ${this.hbService.asUser}`)
-      this.hbService.logger(`Created service user: ${this.hbService.asUser}`, 'info')
+      this.hbService.logger.log(`Created service user: ${this.hbService.asUser}`)
       if (this.hbService.addGroup) {
         execSync(`usermod -a -G ${this.hbService.addGroup} ${this.hbService.asUser}`, { timeout: 10000 })
-        this.hbService.logger(`Added ${this.hbService.asUser} to group ${this.hbService.addGroup}`, 'info')
+        this.hbService.logger.log(`Added ${this.hbService.asUser} to group ${this.hbService.addGroup}`)
       }
     }
 
@@ -624,9 +624,8 @@ export class LinuxInstaller extends BasePlatform {
       // A crafted `--user` value could otherwise inject a trailing entry
       // (e.g. `foo, /bin/sh`) and grant NOPASSWD to arbitrary binaries.
       if (!RE_OS_USERNAME.test(this.hbService.asUser)) {
-        this.hbService.logger(
-          `WARNING: Refusing to write /etc/sudoers entry — invalid username "${this.hbService.asUser}".`,
-          'warn',
+        this.hbService.logger.warn(
+          `WARNING: Refusing to write /etc/sudoers entry — invalid username "${this.hbService.asUser}".`
         )
         return
       }
@@ -644,7 +643,7 @@ export class LinuxInstaller extends BasePlatform {
       // Grant the user restricted sudo privileges to /sbin/shutdown
       execSync(`echo '${sudoersEntry}' | sudo EDITOR='tee -a' visudo`)
     } catch (e) {
-      this.hbService.logger('WARNING: Failed to setup /etc/sudoers, you may not be able to shutdown/restart your server from the Homebridge UI.', 'warn')
+      this.hbService.logger.warn('WARNING: Failed to setup /etc/sudoers, you may not be able to shutdown/restart your server from the Homebridge UI.')
     }
   }
 
@@ -684,7 +683,7 @@ export class LinuxInstaller extends BasePlatform {
           execSync(`chmod a+x ${this.hbService.selfPath}`)
         }
       } catch (e) {
-        this.hbService.logger('WARNING: Failed to set permissions', 'warn')
+        this.hbService.logger.warn('WARNING: Failed to set permissions')
       }
     }
   }
@@ -722,15 +721,15 @@ export class LinuxInstaller extends BasePlatform {
 
       // Add ui rule
       execSync(`ufw allow ${this.hbService.uiPort}/tcp 2> /dev/null`)
-      this.hbService.logger(`Added firewall rule to allow inbound traffic on port ${this.hbService.uiPort}/tcp`, 'info')
+      this.hbService.logger.log(`Added firewall rule to allow inbound traffic on port ${this.hbService.uiPort}/tcp`)
 
       // Add bridge rule
       if (bridgePort) {
         execSync(`ufw allow ${bridgePort}/tcp 2> /dev/null`)
-        this.hbService.logger(`Added firewall rule to allow inbound traffic on port ${bridgePort}/tcp`, 'info')
+        this.hbService.logger.log(`Added firewall rule to allow inbound traffic on port ${bridgePort}/tcp`)
       }
     } catch (e) {
-      this.hbService.logger('WARNING: failed to allow ports through firewall.', 'warn')
+      this.hbService.logger.warn('WARNING: failed to allow ports through firewall.')
     }
   }
 
@@ -751,19 +750,19 @@ export class LinuxInstaller extends BasePlatform {
 
       // Add ui rule
       execSync(`firewall-cmd --permanent --add-port=${this.hbService.uiPort}/tcp 2> /dev/null`)
-      this.hbService.logger(`Added firewall rule to allow inbound traffic on port ${this.hbService.uiPort}/tcp`, 'info')
+      this.hbService.logger.log(`Added firewall rule to allow inbound traffic on port ${this.hbService.uiPort}/tcp`)
 
       // Add bridge rule
       if (bridgePort) {
         execSync(`firewall-cmd --permanent --add-port=${bridgePort}/tcp 2> /dev/null`)
-        this.hbService.logger(`Added firewall rule to allow inbound traffic on port ${bridgePort}/tcp`, 'info')
+        this.hbService.logger.log(`Added firewall rule to allow inbound traffic on port ${bridgePort}/tcp`)
       }
 
       // Reload the firewall
       execSync('firewall-cmd --reload 2> /dev/null')
-      this.hbService.logger('Firewall reloaded', 'info')
+      this.hbService.logger.log('Firewall reloaded')
     } catch (e) {
-      this.hbService.logger('WARNING: failed to allow ports through firewall.', 'warn')
+      this.hbService.logger.warn('WARNING: failed to allow ports through firewall.')
     }
   }
 

--- a/src/bin/platforms/win32.ts
+++ b/src/bin/platforms/win32.ts
@@ -52,7 +52,7 @@ export class Win32Installer extends BasePlatform {
       await this.hbService.printPostInstallInstructions()
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -68,10 +68,10 @@ export class Win32Installer extends BasePlatform {
 
     try {
       execFileSync('sc', ['delete', this.hbService.serviceName])
-      this.hbService.logger(`Removed ${this.hbService.serviceName} Service`, 'succeed')
+      this.hbService.logger.success(`Removed ${this.hbService.serviceName} Service`)
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -83,11 +83,11 @@ export class Win32Installer extends BasePlatform {
     this.assertSafeServiceName()
 
     try {
-      this.hbService.logger(`Starting ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Starting ${this.hbService.serviceName} Service...`)
       execFileSync('sc', ['start', this.hbService.serviceName])
-      this.hbService.logger(`${this.hbService.serviceName} Started`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Started`)
     } catch (e) {
-      this.hbService.logger(`Failed to start ${this.hbService.serviceName}`, 'fail')
+      this.hbService.logger.error(`Failed to start ${this.hbService.serviceName}`)
     }
   }
 
@@ -99,11 +99,11 @@ export class Win32Installer extends BasePlatform {
     this.assertSafeServiceName()
 
     try {
-      this.hbService.logger(`Stopping ${this.hbService.serviceName} Service...`)
+      this.hbService.logger.log(`Stopping ${this.hbService.serviceName} Service...`)
       execFileSync('sc', ['stop', this.hbService.serviceName])
-      this.hbService.logger(`${this.hbService.serviceName} Stopped`, 'succeed')
+      this.hbService.logger.success(`${this.hbService.serviceName} Stopped`)
     } catch (e) {
-      this.hbService.logger(`Failed to stop ${this.hbService.serviceName}`, 'fail')
+      this.hbService.logger.error(`Failed to stop ${this.hbService.serviceName}`)
     }
   }
 
@@ -133,10 +133,10 @@ export class Win32Installer extends BasePlatform {
         stdio: 'inherit',
       })
 
-      this.hbService.logger(`Rebuilt modules in ${process.env.UIX_BASE_PATH} for Node.js ${process.version}.`, 'succeed')
+      this.hbService.logger.success(`Rebuilt modules in ${process.env.UIX_BASE_PATH} for Node.js ${process.version}.`)
     } catch (e) {
       console.error(e.toString())
-      this.hbService.logger('ERROR: Failed Operation', 'fail')
+      this.hbService.logger.error('ERROR: Failed Operation')
     }
   }
 
@@ -144,8 +144,8 @@ export class Win32Installer extends BasePlatform {
    * Update Node.js
    */
   public async updateNodejs(job: { target: string, rebuild: boolean }) {
-    this.hbService.logger('ERROR: This command is not supported on Windows.', 'fail')
-    this.hbService.logger(`Please download Node.js v${job.target} from https://nodejs.org/en/download/ and install manually.`, 'fail')
+    this.hbService.logger.error('ERROR: This command is not supported on Windows.')
+    this.hbService.logger.error(`Please download Node.js v${job.target} from https://nodejs.org/en/download/ and install manually.`)
   }
 
   /**
@@ -157,7 +157,7 @@ export class Win32Installer extends BasePlatform {
    */
   private assertSafeServiceName() {
     if (!RE_SERVICE_NAME.test(this.hbService.serviceName)) {
-      this.hbService.logger(`ERROR: Refusing to run — invalid service name "${this.hbService.serviceName}".`, 'fail')
+      this.hbService.logger.error(`ERROR: Refusing to run — invalid service name "${this.hbService.serviceName}".`)
       process.exit(1)
     }
   }
@@ -169,8 +169,8 @@ export class Win32Installer extends BasePlatform {
     try {
       execSync('fsutil dirty query %systemdrive% >nul')
     } catch (e) {
-      this.hbService.logger('ERROR: This command must be run as an Administrator', 'fail')
-      this.hbService.logger('Node.js command prompt shortcut -> Right Click -> Run as administrator', 'fail')
+      this.hbService.logger.error('ERROR: This command must be run as an Administrator')
+      this.hbService.logger.error('Node.js command prompt shortcut -> Right Click -> Run as administrator')
       process.exit(1)
     }
   }
@@ -190,7 +190,7 @@ export class Win32Installer extends BasePlatform {
 
     const nssmFile = createWriteStream(nssmPath)
 
-    this.hbService.logger(`Downloading NSSM from ${downloadUrl}`)
+    this.hbService.logger.log(`Downloading NSSM from ${downloadUrl}`)
 
     return new Promise((res, rej) => {
       axios({
@@ -209,7 +209,7 @@ export class Win32Installer extends BasePlatform {
           // Cleanup
           nssmFile.close()
           await remove(nssmPath)
-          this.hbService.logger(`Failed to download nssm: ${e.message}`, 'fail')
+          this.hbService.logger.error(`Failed to download nssm: ${e.message}`)
           process.exit(0)
         })
     })
@@ -234,8 +234,8 @@ export class Win32Installer extends BasePlatform {
     try {
       execSync(openFirewallCmd)
     } catch (e) {
-      this.hbService.logger('Failed to configure firewall rule for Homebridge.', 'warn')
-      this.hbService.logger(e)
+      this.hbService.logger.warn('Failed to configure firewall rule for Homebridge.')
+      this.hbService.logger.log(e)
     }
   }
 }

--- a/test/e2e/hb-service-logger.e2e-spec.ts
+++ b/test/e2e/hb-service-logger.e2e-spec.ts
@@ -1,0 +1,125 @@
+import type { LoggerHost } from '../../src/bin/logger.js'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Logger } from '../../src/bin/logger.js'
+
+const oraInstance = vi.hoisted(() => ({
+  info: vi.fn(),
+  succeed: vi.fn(),
+  fail: vi.fn(),
+  warn: vi.fn(),
+}))
+
+vi.mock('ora', () => ({
+  default: () => oraInstance,
+}))
+
+describe('HbServiceLogger (e2e)', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore()
+  })
+
+  describe('run mode', () => {
+    it('should fall back to console.log when no log file is open yet', () => {
+      const host: LoggerHost = { action: 'run' }
+      const logger = new Logger(host)
+
+      logger.log('storage path check')
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+      const line = consoleLogSpy.mock.calls[0][0] as string
+      expect(line).toContain('[HB Supervisor]')
+      expect(line).toContain('[INFO] storage path check')
+    })
+
+    it('should pick up a log file opened after the logger was created', () => {
+      // Mirrors the real `run` sequence: the logger is first used before
+      // startLog() assigns logFile, then again afterwards. The same Logger
+      // instance must write to the file once it exists.
+      const written: string[] = []
+      const host: LoggerHost = { action: 'run' }
+      const logger = new Logger(host)
+
+      logger.log('before log file exists')
+
+      host.logFile = { write: (chunk: string) => written.push(chunk) } as unknown as LoggerHost['logFile']
+      logger.log('after log file exists')
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(1)
+      expect(consoleLogSpy.mock.calls[0][0]).toContain('[INFO] before log file exists')
+      expect(written).toHaveLength(1)
+      expect(written[0]).toContain('[HB Supervisor]')
+      expect(written[0]).toContain('[INFO] after log file exists')
+      expect(written[0].endsWith('\n')).toBe(true)
+    })
+
+    it('should tag each level in the log file output', () => {
+      const written: string[] = []
+      const host: LoggerHost = {
+        action: 'run',
+        logFile: { write: (chunk: string) => written.push(chunk) } as unknown as LoggerHost['logFile'],
+      }
+      const logger = new Logger(host)
+
+      logger.log('a')
+      logger.success('b')
+      logger.error('c')
+      logger.warn('d')
+      logger.debug('e')
+      logger.verbose('f')
+
+      expect(written).toHaveLength(6)
+      expect(written[0]).toContain('[INFO] a')
+      expect(written[1]).toContain('[SUCCESS] b')
+      expect(written[2]).toContain('[ERROR] c')
+      expect(written[3]).toContain('[WARN] d')
+      expect(written[4]).toContain('[DEBUG] e')
+      expect(written[5]).toContain('[VERBOSE] f')
+      expect(consoleLogSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('interactive (non-run) mode', () => {
+    it('should map levels to the ora spinner methods', () => {
+      const host: LoggerHost = { action: 'install' }
+      const logger = new Logger(host)
+
+      logger.log('info msg')
+      logger.debug('debug msg')
+      logger.verbose('verbose msg')
+      logger.success('success msg')
+      logger.error('error msg')
+      logger.warn('warn msg')
+
+      expect(oraInstance.info).toHaveBeenCalledTimes(3)
+      expect(oraInstance.info).toHaveBeenCalledWith('info msg')
+      expect(oraInstance.info).toHaveBeenCalledWith('debug msg')
+      expect(oraInstance.info).toHaveBeenCalledWith('verbose msg')
+      expect(oraInstance.succeed).toHaveBeenCalledWith('success msg')
+      expect(oraInstance.fail).toHaveBeenCalledWith('error msg')
+      expect(oraInstance.warn).toHaveBeenCalledWith('warn msg')
+    })
+
+    it('should not write to the log file even when one is open', () => {
+      const written: string[] = []
+      const host: LoggerHost = {
+        action: 'status',
+        logFile: { write: (chunk: string) => written.push(chunk) } as unknown as LoggerHost['logFile'],
+      }
+      const logger = new Logger(host)
+
+      logger.log('status check')
+
+      expect(written).toHaveLength(0)
+      expect(oraInstance.info).toHaveBeenCalledWith('status check')
+    })
+  })
+})


### PR DESCRIPTION
## :recycle: Current situation

This is Part 1 of a three-part change
Part 2: https://github.com/homebridge/homebridge-config-ui-x/pull/2875
Part 3: https://github.com/homebridge/homebridge-config-ui-x/pull/2876

The end goal of these three PRs is to suppress some verbose log messages in the config UI. HBService is particularly guilty because there is only a single `logger()` function that treats all message levels equally in the log file.

## :bulb: Proposed solution

This PR replaces the `logger()` function with a class that behaves more like `logger.service`

One consequence to note is that the level tag will be written to the log file. For example:

`[7/2/2026, 11:44:45 AM] [HB Supervisor] [INFO] Started Homebridge v2.1.0 with PID: 49499.`

This is needed down the chain to be able to "decode" the log file in config UI to suppress or colorize the messages, as appropriate

## :gear: Release Notes

See Part 3: https://github.com/homebridge/homebridge-config-ui-x/pull/2876

## :heavy_plus_sign: Additional Information

N/A

### Testing

None added yet, but happy to add some if appropriate or necessary

### Reviewer Nudging

`hb-service.ts` is where the most important changes live