### PR TITLE
[Part 2] Remove log prefix tags from log messages and colorize in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - fix(plugins): resolve `savePluginConfig()` ack so custom ui saves no longer hang (#2869)
 - fix(plugins): remove stale custom ui socket listeners on destroy (#2873)
 - refactor(hb-service): level-based logger — `hb-service run` now writes level tags like `[INFO]` and `[VERBOSE]` into `homebridge.log` (#2874) (@mpatfield)
+- feat(log): strip and colorize hb-service level tags in the log stream (#2875) (@mpatfield)
 
 ### Other Changes
 

--- a/src/core/regex.constants.ts
+++ b/src/core/regex.constants.ts
@@ -70,6 +70,14 @@ export const RE_STABLE_DATE = /^\d{4}-\d{2}-\d{2}$/
 // eslint-disable-next-line no-control-regex
 export const RE_ANSI_COLOUR = /\x1B\[(\d{1,3}(;\d{1,2})?)?[mGK]/g
 
+// Log lines written by the hb-service supervisor, which carry level tags in
+// the form `[HB Supervisor]<ansi reset> [LEVEL] message`. Scoped to the
+// `[HB Supervisor]` marker so Homebridge core and plugin output is untouched.
+// eslint-disable-next-line no-control-regex
+export const RE_SUPERVISOR_DEBUG_LINE = /^.*\[HB Supervisor\](?:\x1B\[\d+m)?\s*\[DEBUG\].*(?:\r?\n\r?|$)/gm
+// eslint-disable-next-line no-control-regex
+export const RE_SUPERVISOR_LEVEL_TAG = /(\[HB Supervisor\](?:\x1B\[\d+m)?\s*)\[(INFO|SUCCESS|ERROR|WARN|DEBUG|VERBOSE)\]\s*([^\r\n]*)/g
+
 // Security
 export const RE_PATH_TRAVERSAL = /^(\.\.(\/|\\|$))+/
 export const RE_STATIC_ASSET_EXT = /^.*\.(?:jpe?g|gif|png|svg|ttf|woff2|css)$/i

--- a/src/modules/log/log.service.ts
+++ b/src/modules/log/log.service.ts
@@ -13,6 +13,7 @@ import { Tail } from 'tail'
 
 import { ConfigService } from '../../core/config/config.service.js'
 import { NodePtyService } from '../../core/node-pty/node-pty.service.js'
+import { RE_SUPERVISOR_DEBUG_LINE, RE_SUPERVISOR_LEVEL_TAG } from '../../core/regex.constants.js'
 import { TermSize } from '../platform-tools/terminal/terminal.interfaces.js'
 
 @Injectable()
@@ -355,23 +356,25 @@ export class LogService {
   private emitMessage(client: EventEmitter, msg: string) {
     let output = msg
 
+    // Only lines written by the hb-service supervisor carry the level tags —
+    // Homebridge core and plugin output must pass through untouched, even if
+    // it happens to contain text like `[DEBUG]`.
     if (process.env.UIX_DEBUG_LOGGING !== '1') {
-      output = output.replace(/^.*\[DEBUG\].*(?:\r?\n|\n\r|$)/gm, '')
+      output = output.replace(RE_SUPERVISOR_DEBUG_LINE, '')
     }
 
-    output = output.replace(/\[(INFO|SUCCESS|ERROR|WARN|DEBUG|VERBOSE)\]\s*([^\r\n]*)/g,
-      (_match, level, content) => {
-        switch (level) {
-          case 'SUCCESS':
-            return green(content)
-          case 'WARN':
-            return yellow(content)
-          case 'ERROR':
-            return red(content)
-          default:
-            return content
-        }
-      })
+    output = output.replace(RE_SUPERVISOR_LEVEL_TAG, (_match, prefix, level, content) => {
+      switch (level) {
+        case 'SUCCESS':
+          return prefix + green(content)
+        case 'WARN':
+          return prefix + yellow(content)
+        case 'ERROR':
+          return prefix + red(content)
+        default:
+          return prefix + content
+      }
+    })
 
     if (output) {
       client.emit('stdout', output)

--- a/src/modules/log/log.service.ts
+++ b/src/modules/log/log.service.ts
@@ -16,12 +16,17 @@ import { NodePtyService } from '../../core/node-pty/node-pty.service.js'
 import { RE_SUPERVISOR_DEBUG_LINE, RE_SUPERVISOR_LEVEL_TAG } from '../../core/regex.constants.js'
 import { TermSize } from '../platform-tools/terminal/terminal.interfaces.js'
 
+// How long a trailing partial line is held back waiting for its terminator
+// before being flushed to the client anyway
+const PARTIAL_LINE_FLUSH_MS = 50
+
 @Injectable()
 export class LogService {
   private command: string[]
   private useNative = false
   private nativeTail: Tail
   private activeClients = new WeakSet<EventEmitter>()
+  private logBuffers = new WeakMap<EventEmitter, { buffer: string, flushTimeout: ReturnType<typeof setTimeout> }>()
 
   constructor(
     @Inject(ConfigService) private readonly configService: ConfigService,
@@ -137,6 +142,7 @@ export class LogService {
       proc.on('exit', (code) => {
         try {
           if (!ending) {
+            this.flushMessage(client)
             client.emit('stdout', '\n\r')
             client.emit('stdout', red(`The log tail command ${command.join(' ')} exited with code ${code}.\n\r`))
             client.emit('stdout', red('Please check the command in your config.json is correct.\n\r\n\r'))
@@ -151,6 +157,7 @@ export class LogService {
       const onEnd = () => {
         ending = true
         this.activeClients.delete(client)
+        this.discardMessageBuffer(client)
 
         client.removeAllListeners('end')
         client.removeAllListeners('disconnect')
@@ -181,6 +188,7 @@ export class LogService {
       term.onExit((code) => {
         try {
           if (!ending) {
+            this.flushMessage(client)
             client.emit('stdout', '\n\r')
             client.emit('stdout', red(`The log tail command ${command.join(' ')} exited with code ${code.exitCode}.\n\r`))
             client.emit('stdout', red('Please check the command in your config.json is correct.\n\r\n\r'))
@@ -202,6 +210,7 @@ export class LogService {
       const onEnd = () => {
         ending = true
         this.activeClients.delete(client)
+        this.discardMessageBuffer(client)
 
         client.removeAllListeners('resize')
         client.removeAllListeners('end')
@@ -276,6 +285,9 @@ export class LogService {
       })
 
       logStream.on('end', () => {
+        // The initial dump is done — flush any held partial line right away
+        // (e.g. when the log file does not end with a newline)
+        this.flushMessage(client)
         logStream.close()
       })
     } catch (e) {
@@ -318,6 +330,7 @@ export class LogService {
     // Cleanup on disconnect
     const onEnd = () => {
       this.activeClients.delete(client)
+      this.discardMessageBuffer(client)
 
       // @ts-expect-error - TS2339: Property removeListener does not exist on type Tail
       this.nativeTail.removeListener('line', onLine)
@@ -354,6 +367,63 @@ export class LogService {
   }
 
   private emitMessage(client: EventEmitter, msg: string) {
+    // Chunks from the pty/stream can split a log line in two, which would let
+    // half a supervisor line slip past the tag handling in processMessage().
+    // Emit up to the last complete line and hold the remainder until its
+    // terminator arrives — or until a short idle timeout, so output that
+    // legitimately ends without a newline still reaches the client.
+    const pending = this.logBuffers.get(client)
+    if (pending) {
+      clearTimeout(pending.flushTimeout)
+    }
+
+    const data = (pending?.buffer ?? '') + msg
+    const lastNewline = data.lastIndexOf('\n')
+
+    // Keep a `\r` directly after the last `\n` with the complete part so
+    // `\n\r` line endings are not split in half
+    const splitAt = lastNewline === -1 ? 0 : (data[lastNewline + 1] === '\r' ? lastNewline + 2 : lastNewline + 1)
+    const partial = data.slice(splitAt)
+
+    if (partial) {
+      this.logBuffers.set(client, {
+        buffer: partial,
+        flushTimeout: setTimeout(() => this.flushMessage(client), PARTIAL_LINE_FLUSH_MS).unref(),
+      })
+    } else {
+      this.logBuffers.delete(client)
+    }
+
+    if (splitAt > 0) {
+      this.processMessage(client, data.slice(0, splitAt))
+    }
+  }
+
+  /**
+   * Emit any held partial line through the normal processing path
+   */
+  private flushMessage(client: EventEmitter) {
+    const pending = this.logBuffers.get(client)
+    if (!pending) {
+      return
+    }
+    clearTimeout(pending.flushTimeout)
+    this.logBuffers.delete(client)
+    this.processMessage(client, pending.buffer)
+  }
+
+  /**
+   * Discard any held partial line without emitting it (client is disconnecting)
+   */
+  private discardMessageBuffer(client: EventEmitter) {
+    const pending = this.logBuffers.get(client)
+    if (pending) {
+      clearTimeout(pending.flushTimeout)
+      this.logBuffers.delete(client)
+    }
+  }
+
+  private processMessage(client: EventEmitter, msg: string) {
     let output = msg
 
     // Only lines written by the hb-service supervisor carry the level tags —

--- a/src/modules/log/log.service.ts
+++ b/src/modules/log/log.service.ts
@@ -7,7 +7,7 @@ import { platform } from 'node:os'
 import process from 'node:process'
 
 import { Inject, Injectable } from '@nestjs/common'
-import { cyan, red, yellow } from 'bash-color'
+import { cyan, green, red, yellow } from 'bash-color'
 import { satisfies } from 'semver'
 import { Tail } from 'tail'
 
@@ -117,7 +117,7 @@ export class LogService {
       // Send stdout data from the process to the client
       proc.stdout?.on('data', (data) => {
         try {
-          client.emit('stdout', data.toString('utf8').split('\n').join('\n\r'))
+          this.emitMessage(client, data.toString('utf8').split('\n').join('\n\r'))
         } catch (e) {
           // The client socket probably closed
         }
@@ -126,7 +126,7 @@ export class LogService {
       // Send stderr data from the process to the client
       proc.stderr?.on('data', (data) => {
         try {
-          client.emit('stdout', data.toString('utf8').split('\n').join('\n\r'))
+          this.emitMessage(client, data.toString('utf8').split('\n').join('\n\r'))
         } catch (e) {
           // The client socket probably closed
         }
@@ -156,7 +156,7 @@ export class LogService {
 
         try {
           proc.kill()
-        } catch (e) {}
+        } catch (e) { }
       }
 
       client.on('end', onEnd)
@@ -173,7 +173,7 @@ export class LogService {
 
       // Send stdout data from the process to the client
       term.onData((data) => {
-        client.emit('stdout', data)
+        this.emitMessage(client, data)
       })
 
       // Send an error message to the client if the log tailing process exits early
@@ -194,7 +194,7 @@ export class LogService {
       client.on('resize', (resize: { rows: number, cols: number }) => {
         try {
           term.resize(resize.cols, resize.rows)
-        } catch (e) {}
+        } catch (e) { }
       })
 
       // Cleanup on disconnect
@@ -208,7 +208,7 @@ export class LogService {
 
         try {
           term.kill()
-        } catch (e) {}
+        } catch (e) { }
         // Really make sure the log tail command is killed when using sudo mode
         if (this.configService.ui.sudo && term && term.pid) {
           exec(`sudo -n kill -9 ${term.pid}`)
@@ -271,7 +271,7 @@ export class LogService {
       const logStream = createReadStream(this.configService.ui.log.path, { start: logStartPosition })
 
       logStream.on('data', (buffer) => {
-        client.emit('stdout', buffer.toString('utf8').split('\n').join('\n\r'))
+        this.emitMessage(client, buffer.toString('utf8').split('\n').join('\n\r'))
       })
 
       logStream.on('end', () => {
@@ -304,7 +304,7 @@ export class LogService {
 
     // Watch for lines and emit to client
     const onLine = (line: string) => {
-      client.emit('stdout', `${line}\n\r`)
+      this.emitMessage(client, `${line}\n\r`)
     }
 
     const onError = (err: Error) => {
@@ -350,5 +350,31 @@ export class LogService {
    */
   private logNotConfigured() {
     this.command = null
+  }
+
+  private emitMessage(client: EventEmitter, msg: string) {
+    let output = msg
+
+    if (process.env.UIX_DEBUG_LOGGING !== '1') {
+      output = output.replace(/^.*\[DEBUG\].*(?:\r?\n|\n\r|$)/gm, '')
+    }
+
+    output = output.replace(/\[(INFO|SUCCESS|ERROR|WARN|DEBUG|VERBOSE)\]\s*([^\r\n]*)/g,
+      (_match, level, content) => {
+        switch (level) {
+          case 'SUCCESS':
+            return green(content)
+          case 'WARN':
+            return yellow(content)
+          case 'ERROR':
+            return red(content)
+          default:
+            return content
+        }
+      })
+
+    if (output) {
+      client.emit('stdout', output)
+    }
   }
 }

--- a/test/e2e/log.gateway.e2e-spec.ts
+++ b/test/e2e/log.gateway.e2e-spec.ts
@@ -8,6 +8,7 @@ import process from 'node:process'
 
 import { FastifyAdapter } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
+import { green, red, yellow } from 'bash-color'
 import { copy, writeFile } from 'fs-extra'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -281,6 +282,88 @@ describe('LogGateway (e2e)', () => {
 
     // Tidy up so beforeEach doesn't see lingering listeners on the spare clients.
     clientB.emit('disconnect')
+  })
+
+  describe('emitMessage', () => {
+    // Mirrors the line format written by the hb-service supervisor:
+    // <grey>[date]<reset> <cyan>[HB Supervisor]<reset> [LEVEL] message
+    const supervisor = '\x1B[37m[1/1/2026, 12:00:00 PM]\x1B[0m \x1B[36m[HB Supervisor]\x1B[0m'
+
+    const originalDebugLogging = process.env.UIX_DEBUG_LOGGING
+
+    beforeEach(() => {
+      delete process.env.UIX_DEBUG_LOGGING
+    })
+
+    afterAll(() => {
+      if (originalDebugLogging === undefined) {
+        delete process.env.UIX_DEBUG_LOGGING
+      } else {
+        process.env.UIX_DEBUG_LOGGING = originalDebugLogging
+      }
+    })
+
+    function emitted(msg: string): string[] {
+      const target = new EventEmitter()
+      const chunks: string[] = []
+      target.on('stdout', (data: string) => chunks.push(data))
+      ;(logService as any).emitMessage(target, msg)
+      return chunks
+    }
+
+    it('strips the level tag from supervisor lines', () => {
+      const [out] = emitted(`${supervisor} [INFO] Started Homebridge.\n\r`)
+
+      expect(out).toContain('[HB Supervisor]')
+      expect(out).not.toContain('[INFO]')
+      expect(out).toContain('Started Homebridge.')
+    })
+
+    it('colorizes supervisor SUCCESS/WARN/ERROR content', () => {
+      expect(emitted(`${supervisor} [SUCCESS] done\n\r`)[0]).toContain(green('done'))
+      expect(emitted(`${supervisor} [WARN] careful\n\r`)[0]).toContain(yellow('careful'))
+      expect(emitted(`${supervisor} [ERROR] broken\n\r`)[0]).toContain(red('broken'))
+    })
+
+    it('suppresses supervisor DEBUG lines when debug logging is off', () => {
+      const chunks = emitted(`${supervisor} [DEBUG] internal detail\n\r`)
+
+      expect(chunks).toHaveLength(0)
+    })
+
+    it('keeps supervisor DEBUG lines when UIX_DEBUG_LOGGING is enabled', () => {
+      process.env.UIX_DEBUG_LOGGING = '1'
+
+      const [out] = emitted(`${supervisor} [DEBUG] internal detail\n\r`)
+
+      expect(out).toContain('internal detail')
+      expect(out).not.toContain('[DEBUG]')
+    })
+
+    it('removes only the supervisor DEBUG line from a multi-line chunk', () => {
+      const [out] = emitted([
+        `${supervisor} [INFO] line one`,
+        `${supervisor} [DEBUG] line two`,
+        '[1/1/2026, 12:00:00 PM] [homebridge-foo] line three',
+        '',
+      ].join('\n\r'))
+
+      expect(out).toContain('line one')
+      expect(out).not.toContain('line two')
+      expect(out).toContain('[homebridge-foo] line three')
+    })
+
+    it('does not drop plugin output that happens to contain [DEBUG]', () => {
+      const [out] = emitted('[1/1/2026, 12:00:00 PM] [homebridge-foo] payload contained [DEBUG] marker\n\r')
+
+      expect(out).toContain('payload contained [DEBUG] marker')
+    })
+
+    it('does not strip or recolour tags in plugin output', () => {
+      const line = '[1/1/2026, 12:00:00 PM] [homebridge-foo] upstream said [ERROR] oops\n\r'
+
+      expect(emitted(line)[0]).toBe(line)
+    })
   })
 
   afterAll(async () => {

--- a/test/e2e/log.gateway.e2e-spec.ts
+++ b/test/e2e/log.gateway.e2e-spec.ts
@@ -364,6 +364,72 @@ describe('LogGateway (e2e)', () => {
 
       expect(emitted(line)[0]).toBe(line)
     })
+
+    it('suppresses a supervisor DEBUG line split across two chunks', () => {
+      const target = new EventEmitter()
+      const chunks: string[] = []
+      target.on('stdout', (data: string) => chunks.push(data))
+      const service = logService as any
+
+      service.emitMessage(target, `${supervisor} [DEB`)
+      service.emitMessage(target, 'UG] secret detail\n\r')
+
+      expect(chunks).toHaveLength(0)
+
+      service.emitMessage(target, `${supervisor} [INFO] visible\n\r`)
+
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0]).toContain('visible')
+      expect(chunks[0]).not.toContain('secret detail')
+    })
+
+    it('strips the tag from a supervisor line split across two chunks', () => {
+      const target = new EventEmitter()
+      const chunks: string[] = []
+      target.on('stdout', (data: string) => chunks.push(data))
+      const service = logService as any
+
+      service.emitMessage(target, `${supervisor} [SUC`)
+      service.emitMessage(target, 'CESS] made it\n\r')
+
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0]).toContain(green('made it'))
+      expect(chunks[0]).not.toContain('[SUCCESS]')
+    })
+
+    it('emits complete lines immediately while holding the partial remainder', () => {
+      const target = new EventEmitter()
+      const chunks: string[] = []
+      target.on('stdout', (data: string) => chunks.push(data))
+      const service = logService as any
+
+      service.emitMessage(target, 'line a\n\rline b partial')
+
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0]).toBe('line a\n\r')
+
+      service.emitMessage(target, ' now complete\n\r')
+
+      expect(chunks).toHaveLength(2)
+      expect(chunks[1]).toBe('line b partial now complete\n\r')
+    })
+
+    it('flushes a held partial line after a short idle timeout', async () => {
+      const target = new EventEmitter()
+      const chunks: string[] = []
+      target.on('stdout', (data: string) => chunks.push(data))
+      const service = logService as any
+
+      service.emitMessage(target, `${supervisor} [INFO] no trailing newline`)
+
+      expect(chunks).toHaveLength(0)
+
+      await new Promise(res => setTimeout(res, 150))
+
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0]).toContain('no trailing newline')
+      expect(chunks[0]).not.toContain('[INFO]')
+    })
   })
 
   afterAll(async () => {


### PR DESCRIPTION
## :recycle: Current situation

This is Part 2 of a three-part change
Part 1: https://github.com/homebridge/homebridge-config-ui-x/pull/2874
Part 3: https://github.com/homebridge/homebridge-config-ui-x/pull/2876

This builds upon https://github.com/homebridge/homebridge-config-ui-x/pull/2874 with end goal to suppress some verbose log messages in the config UI. 

Now that the log messages from `hb-service` include level tags, we need to consume them.

## :bulb: Proposed solution

This PR takes the messages that look like this:

`[7/2/2026, 11:44:45 AM] [HB Supervisor] [INFO] Message A`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] [SUCCESS] Message B`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] [ERROR] Message C`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] [WARN] Message D`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] [DEBUG] Message E`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] [VERBOSE] Message F`

And converts them, as appropriate:

`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message A`
`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message B` <-- green
`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message C` <-- red
`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message D` <-- yellow
`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message E` <-- white if debug enabled, otherwise completely removed
`[7/2/2026, 11:44:45 AM] [HB Supervisor] Message F`

## :gear: Release Notes

See Part 3: https://github.com/homebridge/homebridge-config-ui-x/pull/2876

## :heavy_plus_sign: Additional Information

N/A

### Testing

None added yet, but happy to add some if appropriate or necessary

### Reviewer Nudging

`emitMessage()` is the most important addition