### PR TITLE
[Part 3] Suppress several messages that are debug in nature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 - fix(plugins): remove stale custom ui socket listeners on destroy (#2873)
 - refactor(hb-service): level-based logger — `hb-service run` now writes level tags like `[INFO]` and `[VERBOSE]` into `homebridge.log` (#2874) (@mpatfield)
 - feat(log): strip and colorize hb-service level tags in the log stream (#2875) (@mpatfield)
+- refactor(log): downgrade noisy log messages to debug (#2876) (@mpatfield)
 
 ### Other Changes
 

--- a/src/bin/hb-service.ts
+++ b/src/bin/hb-service.ts
@@ -304,7 +304,7 @@ export class HomebridgeServiceHelper {
     }
 
     // Work out the log path
-    this.logger.log(`Logging to ${this.logPath}.`)
+    this.logger.debug(`Logging to ${this.logPath}.`)
 
     // Redirect all stdout to the log file
     this.logFile = createWriteStream(this.logPath, { flags: 'a' })
@@ -382,8 +382,8 @@ export class HomebridgeServiceHelper {
       process.exit(0)
     }
 
-    this.logger.log(`Homebridge storage path: ${this.storagePath}.`)
-    this.logger.log(`Homebridge config path: ${process.env.UIX_CONFIG_PATH}.`)
+    this.logger.debug(`Homebridge storage path: ${this.storagePath}.`)
+    this.logger.debug(`Homebridge config path: ${process.env.UIX_CONFIG_PATH}.`)
 
     // Start the interval to truncate the logs every two hours
     setInterval(() => {
@@ -402,19 +402,19 @@ export class HomebridgeServiceHelper {
       await this.configCheck()
 
       // Log os info
-      this.logger.log(`OS: ${type()} ${release()} ${arch()}.`)
-      this.logger.log(`Node.js ${process.version} ${process.execPath}.`)
+      this.logger.debug(`OS: ${type()} ${release()} ${arch()}.`)
+      this.logger.debug(`Node.js ${process.version} ${process.execPath}.`)
 
       // Work out the homebridge binary path
       this.homebridgeBinary = await this.findHomebridgePath()
-      this.logger.log(`Homebridge path: ${this.homebridgeBinary}.`)
+      this.logger.debug(`Homebridge path: ${this.homebridgeBinary}.`)
 
       // Load startup options if they exist
       await this.loadHomebridgeStartupOptions()
 
       // Get the standalone ui binary on this system
       this.uiBinary = resolve(process.env.UIX_BASE_PATH, 'dist', 'bin', 'standalone.js')
-      this.logger.log(`UI path: ${this.uiBinary}.`)
+      this.logger.debug(`UI path: ${this.uiBinary}.`)
     } catch (e) {
       this.logger.log(e.message)
       process.exit(1)
@@ -447,7 +447,7 @@ export class HomebridgeServiceHelper {
    */
   private startExitHandler() {
     const exitHandler = () => {
-      this.logger.log('Stopping services...')
+      this.logger.debug('Stopping services...')
       try {
         this.homebridge.kill()
       } catch (e) {}
@@ -481,11 +481,11 @@ export class HomebridgeServiceHelper {
     }
 
     if (this.homebridgeOpts.length) {
-      this.logger.log(`Starting Homebridge with extra flags: ${this.homebridgeOpts.join(' ')}.`)
+      this.logger.debug(`Starting Homebridge with extra flags: ${this.homebridgeOpts.join(' ')}.`)
     }
 
     if (Object.keys(this.homebridgeCustomEnv).length) {
-      this.logger.log(`Starting Homebridge with custom env: ${JSON.stringify(this.homebridgeCustomEnv)}.`)
+      this.logger.debug(`Starting Homebridge with custom env: ${JSON.stringify(this.homebridgeCustomEnv)}.`)
     }
 
     // Env setup
@@ -525,7 +525,7 @@ export class HomebridgeServiceHelper {
       this.ipcService.setHomebridgeVersion(this.homebridgePackage.version)
     }
 
-    this.logger.log(`Started Homebridge v${this.homebridgePackage.version} with PID: ${this.homebridge.pid}.`)
+    this.logger.success(`Started Homebridge v${this.homebridgePackage.version} with PID: ${this.homebridge.pid}.`)
 
     // Buffer per-stream output and flush whole lines so concurrent
     // stdout/stderr writes don't interleave mid-line in the log file.

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,7 +144,7 @@ async function bootstrap(): Promise<NestFastifyApplication> {
   app.useGlobalFilters(new SpaFilter())
 
   // (13) Start listening - woohoo!
-  logger.warn(`Homebridge UI v${configService.package.version} is listening on ${startupConfig.host} port ${configService.ui.port}.`)
+  logger.success(`Homebridge UI v${configService.package.version} is listening on ${startupConfig.host} port ${configService.ui.port}.`)
   await app.listen(configService.ui.port, startupConfig.host)
 
   // Advertise the HTTP service via mDNS/Bonjour for easy discovery (if enabled)
@@ -174,7 +174,7 @@ async function bootstrap(): Promise<NestFastifyApplication> {
   }
 
   const handleShutdown = (signal: string) => {
-    logger.log(`Received ${signal}, starting graceful shutdown...`)
+    logger.debug(`Received ${signal}, starting graceful shutdown...`)
     if (bonjour) {
       try {
         logger.log('Shutting down mDNS service advertising...')

--- a/src/modules/backup/backup.service.ts
+++ b/src/modules/backup/backup.service.ts
@@ -194,7 +194,7 @@ export class BackupService {
     scheduleRule.second = Math.floor(Math.random() * 59)
 
     this.schedulerService.scheduleJob('instance-backup', scheduleRule, () => {
-      this.logger.log('Running scheduled instance backup...')
+      this.logger.debug('Running scheduled instance backup...')
       this.runScheduledBackupJob().catch((e) => {
         this.logger.error(`Scheduled instance backup failed as ${e?.message || e}.`)
       })
@@ -220,7 +220,7 @@ export class BackupService {
     const backupFileName = `homebridge-backup-${instanceId}.${Date.now().toString()}.tar.gz`
     const backupPath = resolve(backupDir, backupFileName)
 
-    this.logger.log(`Creating temporary backup archive at ${backupPath}.`)
+    this.logger.debug(`Creating temporary backup archive at ${backupPath}.`)
 
     try {
       // Resolve the real path of the storage directory (in case it's a symbolic link)

--- a/src/modules/config-editor/config-editor.service.ts
+++ b/src/modules/config-editor/config-editor.service.ts
@@ -82,7 +82,7 @@ export class ConfigEditorService implements OnApplicationBootstrap {
     this.logger.debug(`Next config.json backup cleanup scheduled for ${scheduleRule.nextInvocationDate(new Date()).toString()}.`)
 
     this.schedulerService.scheduleJob('cleanup-config-backups', scheduleRule, () => {
-      this.logger.log('Running job to cleanup config.json backup files older than 60 days...')
+      this.logger.debug('Running job to cleanup config.json backup files older than 60 days...')
       this.cleanupConfigBackups().catch((e) => {
         this.logger.error(`config.json backup cleanup failed as ${e?.message || e}.`)
       })

--- a/src/modules/platform-tools/terminal/terminal.service.ts
+++ b/src/modules/platform-tools/terminal/terminal.service.ts
@@ -135,7 +135,9 @@ export class TerminalService {
     client.on('resize', (resize: TermSize) => {
       try {
         term.resize(resize.cols, resize.rows)
-      } catch (e) { }
+      } catch {
+        // The terminal has probably already exited
+      }
     })
 
     // cleanup on disconnect
@@ -150,7 +152,9 @@ export class TerminalService {
       try {
         this.logger.debug('Terminal session ended.')
         term.kill()
-      } catch (e) { }
+      } catch {
+        // The terminal has probably already exited
+      }
     }
 
     client.on('end', onEnd.bind(this))
@@ -240,7 +244,9 @@ export class TerminalService {
       // Resize to match current client
       try {
         TerminalService.persistentTerminal.resize(size.cols, size.rows)
-      } catch (e) { }
+      } catch {
+        // The terminal has probably already exited
+      }
     }
 
     // Clean up any existing listeners on this client before adding new ones
@@ -281,7 +287,9 @@ export class TerminalService {
         if (TerminalService.persistentTerminal) {
           TerminalService.persistentTerminal.resize(resize.cols, resize.rows)
         }
-      } catch (e) { }
+      } catch {
+        // The terminal has probably already exited
+      }
     })
 
     // Clean up client listeners on disconnect (but keep terminal alive)

--- a/src/modules/platform-tools/terminal/terminal.service.ts
+++ b/src/modules/platform-tools/terminal/terminal.service.ts
@@ -86,7 +86,7 @@ export class TerminalService {
   }
 
   private async createNewTerminal(client: WsEventEmitter, size: TermSize) {
-    this.logger.log('Starting new terminal session.')
+    this.logger.debug('Starting new terminal session.')
 
     // Get the preferred shell for the current platform
     const shell = await this.getPreferredShell()
@@ -135,7 +135,7 @@ export class TerminalService {
     client.on('resize', (resize: TermSize) => {
       try {
         term.resize(resize.cols, resize.rows)
-      } catch (e) {}
+      } catch (e) { }
     })
 
     // cleanup on disconnect
@@ -148,9 +148,9 @@ export class TerminalService {
       client.removeAllListeners('disconnect')
 
       try {
-        this.logger.log('Terminal session ended.')
+        this.logger.debug('Terminal session ended.')
         term.kill()
-      } catch (e) {}
+      } catch (e) { }
     }
 
     client.on('end', onEnd.bind(this))
@@ -240,7 +240,7 @@ export class TerminalService {
       // Resize to match current client
       try {
         TerminalService.persistentTerminal.resize(size.cols, size.rows)
-      } catch (e) {}
+      } catch (e) { }
     }
 
     // Clean up any existing listeners on this client before adding new ones
@@ -281,7 +281,7 @@ export class TerminalService {
         if (TerminalService.persistentTerminal) {
           TerminalService.persistentTerminal.resize(resize.cols, resize.rows)
         }
-      } catch (e) {}
+      } catch (e) { }
     })
 
     // Clean up client listeners on disconnect (but keep terminal alive)

--- a/src/modules/server/server.service.ts
+++ b/src/modules/server/server.service.ts
@@ -242,7 +242,7 @@ export class ServerService {
    * Restart the server
    */
   public async restartServer() {
-    this.logger.log('Homebridge restart request received.')
+    this.logger.debug('Homebridge restart request received.')
 
     if (!await this.configService.uiRestartRequired() && !await this.nodeVersionChanged()) {
       this.logger.log('UI/Bridge settings have not changed - only restarting Homebridge process.')
@@ -257,7 +257,7 @@ export class ServerService {
     setTimeout(() => {
       const restartCmd = this.configService.ui.restart
       if (!restartCmd) {
-        this.logger.log('Sending SIGTERM to process...')
+        this.logger.debug('Sending SIGTERM to process...')
         process.kill(process.pid, 'SIGTERM')
         return
       }

--- a/src/modules/status/status.service.ts
+++ b/src/modules/status/status.service.ts
@@ -90,7 +90,7 @@ export class StatusService {
         this.getMemoryUsagePoint()
       }, 10000)
     } else {
-      this.logger.warn('Server metrics monitoring disabled.')
+      this.logger.debug('Server metrics monitoring disabled.')
     }
 
     this.homebridgeIpcService.on('serverStatusUpdate', (data: HomebridgeStatusUpdate) => {

--- a/test/e2e/logger.e2e-spec.ts
+++ b/test/e2e/logger.e2e-spec.ts
@@ -1,0 +1,84 @@
+import process from 'node:process'
+
+import { green, red, yellow } from 'bash-color'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Logger } from '../../src/core/logger/logger.service.js'
+
+describe('Logger (e2e)', () => {
+  let logger: Logger
+
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+  let debugSpy: ReturnType<typeof vi.spyOn>
+
+  const originalDebugLogging = process.env.UIX_DEBUG_LOGGING
+
+  beforeEach(() => {
+    delete process.env.UIX_DEBUG_LOGGING
+
+    logger = new Logger()
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterAll(() => {
+    if (originalDebugLogging === undefined) {
+      delete process.env.UIX_DEBUG_LOGGING
+    } else {
+      process.env.UIX_DEBUG_LOGGING = originalDebugLogging
+    }
+  })
+
+  it('log() writes the plain message with the prefix', () => {
+    logger.log('hello')
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), 'hello')
+  })
+
+  it('success() writes the message in green', () => {
+    logger.success('all good')
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), green('all good'))
+  })
+
+  it('warn() writes the message in yellow', () => {
+    logger.warn('careful')
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), yellow('careful'))
+  })
+
+  it('error() writes the message in red', () => {
+    logger.error('broken')
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), red('broken'))
+  })
+
+  it('debug() is suppressed when UIX_DEBUG_LOGGING is not enabled', () => {
+    logger.debug('hidden detail')
+
+    expect(debugSpy).not.toHaveBeenCalled()
+  })
+
+  it('debug() writes when UIX_DEBUG_LOGGING is enabled', () => {
+    process.env.UIX_DEBUG_LOGGING = '1'
+
+    logger.debug('shown detail')
+
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), green('shown detail'))
+  })
+
+  it('verbose() writes regardless of UIX_DEBUG_LOGGING', () => {
+    logger.verbose('extra detail')
+
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('[Homebridge UI]'), 'extra detail')
+  })
+})

--- a/test/e2e/platform-tools-terminal.e2e-spec.ts
+++ b/test/e2e/platform-tools-terminal.e2e-spec.ts
@@ -166,6 +166,24 @@ describe('PlatformToolsTerminal (e2e)', () => {
     expect(mockTerm.resize).toHaveBeenCalledWith(20, 25)
   })
 
+  it('ON /platform-tools/terminal/start-session (resize failure is tolerated)', async () => {
+    terminalGateway.startTerminalSession(client, size)
+
+    await new Promise(res => setTimeout(res, 100))
+
+    expect(nodePtyService.spawn).toHaveBeenCalled()
+
+    // A resize on a terminal that has already exited must not crash the session
+    vi.mocked(mockTerm.resize).mockImplementationOnce(() => {
+      throw new Error('read EPIPE')
+    })
+    expect(() => client.emit('resize', { cols: 20, rows: 25 })).not.toThrow()
+
+    // The session is still usable afterwards
+    client.emit('stdin', 'help')
+    expect(mockTerm.write).toHaveBeenCalledWith('help')
+  })
+
   describe('HTTP Endpoints', () => {
     beforeEach(async () => {
       authorization = `bearer ${(await app.inject({


### PR DESCRIPTION
## :recycle: Current situation

This is Part 3 of a three-part change
Part 1: https://github.com/homebridge/homebridge-config-ui-x/pull/2874
Part 2: https://github.com/homebridge/homebridge-config-ui-x/pull/2875

This builds upon https://github.com/homebridge/homebridge-config-ui-x/pull/2874. HBService is particularly guilty of verbose logging but there are some other log messages in Config UI that seem unnecessary unless debug is enabled.

## :bulb: Proposed solution

This PR takes a bunch of messages that are verbose in nature and changes them from "info" to "debug"

Note that this PR relies on https://github.com/homebridge/homebridge-config-ui-x/pull/2874, so that needs to land first, and then this can be rebased on top.

## :gear: Release Notes

- Suppressed overly verbose log messages coming from `[HB Supervisor]` and `[Homebridge UI`

## :heavy_plus_sign: Additional Information

N/A

### Testing

None added yet, but happy to add some if appropriate or necessary

### Reviewer Nudging

This includes commits from https://github.com/homebridge/homebridge-config-ui-x/pull/2874

Recommend only looking at the changes in this commit for this PR: https://github.com/homebridge/homebridge-config-ui-x/commit/a80c339ed3ea36d8c6ccc3447f827425ac568110