### PR TITLE
fix(auth): mint hb-session on bootstrap so custom plugin UIs work after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 
 ## v5.25.1 (Pending Release)
 
+### UI Changes
+
+- fix(auth): mint `hb-session` on bootstrap so custom plugin UIs work after mid-session upgrades (#2893)
+
 ### Other Changes
 
 - fix: remove unsupported npm flag `--unsafe-perm` (#2891)

--- a/ui/src/app/core/auth/auth.service.ts
+++ b/ui/src/app/core/auth/auth.service.ts
@@ -90,6 +90,20 @@ export class AuthService {
       return
     }
     this.validateToken(token)
+
+    // CookieAuthGuard on /api/plugins/settings-ui/* requires an HttpOnly
+    // hb-session cookie that is only set on login/refresh/noauth. A Bearer
+    // token restored from localStorage after upgrading mid-session (or any
+    // bootstrap without a prior login in this browser) leaves custom plugin
+    // UIs returning 401 until the user re-logs in (#2893). Mint the cookie
+    // here via refresh; best-effort so a failed refresh never blocks boot.
+    if (this.$settings.formAuth !== false && this.token) {
+      try {
+        await this.refreshSession()
+      } catch (err) {
+        console.warn('Failed to mint hb-session cookie on bootstrap:', err)
+      }
+    }
   }
 
   public async checkToken() {


### PR DESCRIPTION
## Summary

- After upgrading to 5.25.0 mid-session, custom plugin settings UIs load blank because `CookieAuthGuard` requires an `hb-session` cookie that existing Bearer-only sessions never received (#2893).
- On bootstrap, after a successful `loadToken()`, call `refreshSession()` (already uses `withCredentials: true`) so the server sets `hb-session` without forcing a logout/login.
- Best-effort: a failed refresh is logged and does not block boot or clear the Bearer session.

## Test plan

- [ ] Log in on a build without this fix (or clear the `hb-session` cookie while keeping the Bearer token in `localStorage`), open a custom-UI plugin settings modal → confirm blank iframe / `401` on `/api/plugins/settings-ui/.../index.html`.
- [ ] Apply this change, hard-refresh the UI (keep the same Bearer session), open the same custom-UI plugin settings → iframe loads.
- [ ] Fresh login still works; custom UI still loads.
- [ ] With `ui.auth === 'none'`, UI still boots (guard bypasses cookie; bootstrap skips refresh when `formAuth === false`).

Fixes #2893