### PR TITLE
fix(auth): await tokenReady so hb-session mint finishes before custom plugin UIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 
 ### UI Changes
 
+- fix(auth): await bootstrap `tokenReady` in auth/admin guards so `hb-session` is minted before custom plugin UIs can open (#2893) (@tbaur)
 - fix(auth): mint `hb-session` on bootstrap so custom plugin UIs work after mid-session upgrades (#2893) (@tbaur)
 - fix(plugins): improve child bridge disabled save button state (#2892) (@khiscott)
 - fix(status): show warning on update widget when multiple hb installs found (#2897) (@aguynamedjoetoo)

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -303,6 +303,18 @@ describe('AuthController (e2e)', () => {
     expect(res.json()).toHaveProperty('expires_in')
     // Verify the token is valid (length and structure) - JWT uses base64url which includes - and _ chars
     expect(res.json().access_token).toMatch(RE_JWT)
+
+    // #2893/#2894: bootstrap mints hb-session by calling refresh with the
+    // restored Bearer token. The Set-Cookie must be present and scoped to
+    // the custom plugin UI path so CookieAuthGuard can accept the iframe.
+    const setCookie = res.headers['set-cookie']
+    const cookieHeaders = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
+    const hbSession = cookieHeaders.find(c => c.startsWith('hb-session='))
+    expect(hbSession).toBeTruthy()
+    expect(hbSession).toContain('HttpOnly')
+    expect(hbSession).toContain('Path=/api/plugins/settings-ui/')
+    const cookieValue = hbSession!.slice('hb-session='.length).split(';')[0]
+    expect(cookieValue).toMatch(RE_JWT)
   })
 
   it('POST /auth/refresh (invalid token)', async () => {

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -91,6 +91,45 @@ describe('PluginsSettingsUiController (e2e)', () => {
     expect(res.statusCode).toBe(401)
   })
 
+  it('Bearer-only session mints hb-session via refresh then loads settings-ui (#2893)', async () => {
+    // Mid-session upgrade path: valid Bearer token in localStorage, but no
+    // hb-session cookie (never set on ≤5.24.x sessions). Bootstrap calls
+    // POST /auth/refresh; the Set-Cookie must be enough for CookieAuthGuard.
+    const loginRes = await app.inject({
+      method: 'POST',
+      path: '/auth/login',
+      payload: { username: 'admin', password: 'admin' },
+    })
+    const { access_token } = JSON.parse(loginRes.body)
+
+    const denied = await app.inject({
+      method: 'GET',
+      path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+    })
+    expect(denied.statusCode).toBe(401)
+
+    const refreshRes = await app.inject({
+      method: 'POST',
+      path: '/auth/refresh',
+      headers: { authorization: `bearer ${access_token}` },
+    })
+    expect(refreshRes.statusCode).toBe(201)
+
+    const setCookie = refreshRes.headers['set-cookie']
+    const cookieHeaders = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
+    const hbSessionHeader = cookieHeaders.find(c => c.startsWith('hb-session='))
+    expect(hbSessionHeader).toBeTruthy()
+    const cookiePair = hbSessionHeader!.split(';')[0]
+
+    const allowed = await app.inject({
+      method: 'GET',
+      path: '/plugins/settings-ui/homebridge-mock-plugin/index.html',
+      headers: { cookie: cookiePair },
+    })
+    expect(allowed.statusCode).toBe(200)
+    expect(allowed.body).toContain('Hello World')
+  })
+
   it('GET /plugins/settings-ui/:plugin-name/ (invalid cookie → 401)', async () => {
     const res = await app.inject({
       method: 'GET',

--- a/ui/src/app/core/auth/guards/admin.guard.ts
+++ b/ui/src/app/core/auth/guards/admin.guard.ts
@@ -21,6 +21,12 @@ export const adminGuard: CanActivateFn = async (_next, state) => {
     await firstValueFrom($settings.onSettingsLoaded)
   }
 
+  // Wait for bootstrap loadToken() (hb-session mint + in-memory token)
+  // before the admin refresh below. Without this, a concurrent
+  // refreshSession() during bootstrap hits isRefreshing and no-ops,
+  // skipping the admin-demotion check on cold load.
+  await $auth.tokenReady
+
   // If not using form auth, get a token automatically
   if ($settings.formAuth === false) {
     await $auth.noauth()

--- a/ui/src/app/core/auth/guards/auth.guard.ts
+++ b/ui/src/app/core/auth/guards/auth.guard.ts
@@ -17,6 +17,12 @@ export const authGuard: CanActivateFn = async (_next, state) => {
     await firstValueFrom($settings.onSettingsLoaded)
   }
 
+  // Wait for bootstrap loadToken() — including the best-effort
+  // hb-session mint via /auth/refresh (#2893/#2894) — so a fast first
+  // navigation cannot open a custom plugin UI iframe before the cookie
+  // exists (which would 401 under CookieAuthGuard).
+  await $auth.tokenReady
+
   // Fresh install: short-circuit straight to the setup wizard instead of
   // bouncing through /login first
   if ($settings.env.setupWizardComplete === false) {


### PR DESCRIPTION
## Summary

- Triple-validated [#2894](https://github.com/homebridge/homebridge-config-ui-x/pull/2894) / [#2893](https://github.com/homebridge/homebridge-config-ui-x/issues/2893): the bootstrap `refreshSession()` approach is correct (`POST /auth/refresh` sets `hb-session` with the right `Path`/`HttpOnly` flags; Bearer restore + `withCredentials` is the right mint path).
- Gap: `authGuard` / `adminGuard` did not `await tokenReady`. After settings load, `loadToken()` yields on the mint `refresh`, so a fast first navigation could open a custom-UI iframe before the cookie existed (still 401), and `adminGuard`'s concurrent `refreshSession()` could hit `isRefreshing` and no-op (skipping the admin-demotion check).
- Fix: await `$auth.tokenReady` in both guards (same pattern as `loginGuard`).
- Tests: e2e covers Bearer-only → `POST /auth/refresh` → `Set-Cookie` → settings-ui `200`, and asserts refresh cookie attributes.

## Test plan

- [x] `npx vitest run test/e2e/auth.e2e-spec.ts test/e2e/plugin-settings-ui.e2e-spec.ts` (49 passed)
- [ ] Cold load while logged in as admin → open custom plugin settings → iframe loads (no blank 401)
- [ ] Hard-refresh on an admin route still verifies admin (second refresh after bootstrap, not skipped)
- [ ] `ui.auth === 'none'` still boots

Related: #2893, #2894