### PR TITLE
v5.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `homebridge-config-ui-x` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v5.26.1 (Pending Release)
+
+### Other Changes
+
+- chore(deps): dependency updates
+
+### Homebridge Dependencies
+
+- `@homebridge/hap-client` @ `v5.1.0`
+- `@homebridge/node-pty-prebuilt-multiarch` @ `v0.13.1`
+- `@homebridge/plugin-ui-utils` @ `v2.2.5`
+
 ## v5.26.0 (2026-07-18)
 
 ### UI Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 ### Other Changes
 
 - chore(deps): dependency updates
+- fix(plugins): drop the npm_config_unsafe_perm env var from npm spawns (#2891)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `homebridge-config-ui-x` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
-## v5.26.1 (Pending Release)
+## v5.27.0 (2026-07-19)
 
 ### UI Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 
 - chore(deps): dependency updates
 - fix(plugins): drop the npm_config_unsafe_perm env var from npm spawns (#2891)
+- feat(plugins): pass plugin-declared allow-scripts to npm 12 installs (#2909)
 
 ### Homebridge Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `homebridge-config-ui-x` will be documented in this file.
 
 ## v5.26.1 (Pending Release)
 
+### UI Changes
+
+- feat(accessories): show live power on matter outlet tiles
+
 ### Other Changes
 
 - chore(deps): dependency updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-config-ui-x",
-  "version": "5.26.0",
+  "version": "5.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-config-ui-x",
-      "version": "5.26.0",
+      "version": "5.27.0",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.2",
         "semver": "7.8.5",
-        "systeminformation": "5.31.17",
+        "systeminformation": "5.32.0",
         "tail": "2.2.6",
         "tar": "7.5.20",
         "tcp-port-used": "1.0.3",
@@ -96,7 +96,7 @@
         "node": "^22.12.0 || ^24.0.0"
       },
       "optionalDependencies": {
-        "macos-temperature-sensor": "1.0.4",
+        "macos-temperature-sensor": "2.0.0",
         "osx-temperature-sensor": "1.0.8"
       }
     },
@@ -2784,9 +2784,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
-      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.46.tgz",
+      "integrity": "sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2803,18 +2803,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.43",
-        "@swc/core-darwin-x64": "1.15.43",
-        "@swc/core-linux-arm-gnueabihf": "1.15.43",
-        "@swc/core-linux-arm64-gnu": "1.15.43",
-        "@swc/core-linux-arm64-musl": "1.15.43",
-        "@swc/core-linux-ppc64-gnu": "1.15.43",
-        "@swc/core-linux-s390x-gnu": "1.15.43",
-        "@swc/core-linux-x64-gnu": "1.15.43",
-        "@swc/core-linux-x64-musl": "1.15.43",
-        "@swc/core-win32-arm64-msvc": "1.15.43",
-        "@swc/core-win32-ia32-msvc": "1.15.43",
-        "@swc/core-win32-x64-msvc": "1.15.43"
+        "@swc/core-darwin-arm64": "1.15.46",
+        "@swc/core-darwin-x64": "1.15.46",
+        "@swc/core-linux-arm-gnueabihf": "1.15.46",
+        "@swc/core-linux-arm64-gnu": "1.15.46",
+        "@swc/core-linux-arm64-musl": "1.15.46",
+        "@swc/core-linux-ppc64-gnu": "1.15.46",
+        "@swc/core-linux-s390x-gnu": "1.15.46",
+        "@swc/core-linux-x64-gnu": "1.15.46",
+        "@swc/core-linux-x64-musl": "1.15.46",
+        "@swc/core-win32-arm64-msvc": "1.15.46",
+        "@swc/core-win32-ia32-msvc": "1.15.46",
+        "@swc/core-win32-x64-msvc": "1.15.46"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -2826,9 +2826,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
-      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.46.tgz",
+      "integrity": "sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==",
       "cpu": [
         "arm64"
       ],
@@ -2844,9 +2844,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
-      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.46.tgz",
+      "integrity": "sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==",
       "cpu": [
         "x64"
       ],
@@ -2862,9 +2862,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
-      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.46.tgz",
+      "integrity": "sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==",
       "cpu": [
         "arm"
       ],
@@ -2880,9 +2880,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
-      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.46.tgz",
+      "integrity": "sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==",
       "cpu": [
         "arm64"
       ],
@@ -2901,9 +2901,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
-      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.46.tgz",
+      "integrity": "sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==",
       "cpu": [
         "arm64"
       ],
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
-      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.46.tgz",
+      "integrity": "sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==",
       "cpu": [
         "ppc64"
       ],
@@ -2943,9 +2943,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
-      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.46.tgz",
+      "integrity": "sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==",
       "cpu": [
         "s390x"
       ],
@@ -2964,9 +2964,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
-      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.46.tgz",
+      "integrity": "sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==",
       "cpu": [
         "x64"
       ],
@@ -2985,9 +2985,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
-      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.46.tgz",
+      "integrity": "sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==",
       "cpu": [
         "x64"
       ],
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
-      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.46.tgz",
+      "integrity": "sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==",
       "cpu": [
         "arm64"
       ],
@@ -3024,9 +3024,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
-      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.46.tgz",
+      "integrity": "sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==",
       "cpu": [
         "ia32"
       ],
@@ -3042,9 +3042,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.43",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
-      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "version": "1.15.46",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.46.tgz",
+      "integrity": "sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==",
       "cpu": [
         "x64"
       ],
@@ -6277,9 +6277,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6355,9 +6355,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -8030,13 +8030,14 @@
       }
     },
     "node_modules/macos-temperature-sensor": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/macos-temperature-sensor/-/macos-temperature-sensor-1.0.4.tgz",
-      "integrity": "sha512-JROshGB+f+UnsbNwM6SER4AK82fdGmk79ElhH+8xVieCUQ1fxTanTwp7Rv9DTRtmgB6hLcEGvQYL8XsPbAKLUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-temperature-sensor/-/macos-temperature-sensor-2.0.0.tgz",
+      "integrity": "sha512-QPQx5LiKK2HMDYCyRhye1SoBBLeYeRcQQUrXS3TtT/Jk/kuKx66nEhsLM4TJSZcIVAtItU7BahRTkopm2Koh8g==",
       "cpu": [
         "arm64"
       ],
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -10002,9 +10003,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -10022,7 +10023,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10951,9 +10952,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.17",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.17.tgz",
-      "integrity": "sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.32.0.tgz",
+      "integrity": "sha512-7gfXs43T91miPxxTTtrYitotR/8MPsI2gy3XgUMs6kmOE/JCVqZp6nJpx4XkSutoSqDh6+Y2ovvb2A3RQCR+8w==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -10969,7 +10970,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",

--- a/package.json
+++ b/package.json
@@ -115,14 +115,14 @@
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "semver": "7.8.5",
-    "systeminformation": "5.31.17",
+    "systeminformation": "5.32.0",
     "tail": "2.2.6",
     "tar": "7.5.20",
     "tcp-port-used": "1.0.3",
     "unzipper": "0.12.5"
   },
   "optionalDependencies": {
-    "macos-temperature-sensor": "1.0.4",
+    "macos-temperature-sensor": "2.0.0",
     "osx-temperature-sensor": "1.0.8"
   },
   "devDependencies": {
@@ -203,10 +203,10 @@
   },
   "allowScripts": {
     "@homebridge/node-pty-prebuilt-multiarch@0.13.1": true,
-    "macos-temperature-sensor@1.0.4": true,
+    "macos-temperature-sensor@2.0.0": true,
     "osx-temperature-sensor@1.0.8": true,
     "esbuild@0.28.1": true,
-    "@swc/core@1.15.43": true,
+    "@swc/core@1.15.46": true,
     "fsevents@2.3.3": true,
     "@nestjs/core": false,
     "@scarf/scarf": false

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-config-ui-x",
   "displayName": "Homebridge UI",
   "type": "module",
-  "version": "5.26.0",
+  "version": "5.27.0",
   "description": "A web based management, configuration and control platform for Homebridge.",
   "author": "oznu <dev@oz.nu>",
   "license": "MIT",

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -66,6 +66,7 @@ const module = require('node:module')
 @Injectable()
 export class PluginsService {
   private _npm: Array<string> | undefined
+  private npmMajorVersion: number | null = null
   private _paths: Array<string> | undefined
 
   /**
@@ -663,6 +664,15 @@ export class PluginsService {
     // If installing, set --omit=dev to prevent installing devDependencies
     installOptions.push('--omit=dev')
     const npmPluginLabel = `${pluginAction.name}@${pluginAction.version}`
+
+    // npm >= 12 blocks dependency lifecycle scripts unless allowlisted (#2909).
+    // Honour the plugin's declared `allowScripts` (plus the plugin itself) so
+    // installs behave as before the policy change, and say so in the log.
+    const allowedScripts = await this.getAllowedInstallScripts(pluginAction.name, pluginAction.version)
+    if (allowedScripts.length) {
+      installOptions.push(`--allow-scripts=${allowedScripts.join(',')}`)
+      client.emit('stdout', yellow(`Allowing install scripts for: ${allowedScripts.join(', ')}.\r\n\r\n`))
+    }
 
     // Clean up the npm cache before any installation
     await this.cleanNpmCache()
@@ -2220,6 +2230,72 @@ export class PluginsService {
     } catch (e) {
       return 'latest'
     }
+  }
+
+  /**
+   * Returns the major version of the npm binary, cached after the first call.
+   * Returns 0 when npm cannot be queried (the caller then skips version-gated
+   * flags rather than risking an unknown-flag hard error).
+   */
+  private getNpmMajorVersion(): number {
+    if (this.npmMajorVersion === null) {
+      try {
+        this.npmMajorVersion = Number.parseInt(execSync('npm --version', { timeout: 10000 }).toString().trim().split('.')[0], 10) || 0
+      } catch (error) {
+        this.logger.debug(`Could not determine npm version: ${error.message}`)
+        this.npmMajorVersion = 0
+      }
+    }
+    return this.npmMajorVersion
+  }
+
+  /**
+   * npm >= 12 refuses to run dependency lifecycle scripts unless they are
+   * explicitly allowlisted (#2909). Build the --allow-scripts list for a
+   * plugin install: the plugin itself plus any dependencies the plugin
+   * declares in its package.json `allowScripts` field (either an array of
+   * package names or an object map of name -> boolean).
+   *
+   * Returns an empty list when the running npm is older than 12 - passing the
+   * flag there would hard-error as an unknown option - or when the registry
+   * lookup fails entirely (the plugin's own name is still allowed in that
+   * case, as installing the plugin is taken as consent for its own script).
+   */
+  private async getAllowedInstallScripts(pluginName: string, pluginVersion: string): Promise<string[]> {
+    if (this.getNpmMajorVersion() < 12) {
+      return []
+    }
+
+    const allowed = new Set<string>([pluginName])
+
+    try {
+      // This fetch must NOT use the minimal-projection accept header
+      // (application/vnd.npm.install-v1+json) used elsewhere in this service:
+      // that projection strips the `allowScripts` field this lookup exists to read.
+      const pkg: INpmRegistryModule = (await firstValueFrom(
+        this.httpService.get(`https://registry.npmjs.org/${encodeURIComponent(pluginName).replace(RE_ENCODED_AT, '@')}`),
+      )).data
+      const manifest = pkg.versions?.[pluginVersion] as (IPackageJson & { allowScripts?: unknown }) | undefined
+      const declared = manifest?.allowScripts
+
+      if (Array.isArray(declared)) {
+        for (const name of declared) {
+          if (typeof name === 'string' && name.length) {
+            allowed.add(name)
+          }
+        }
+      } else if (declared && typeof declared === 'object') {
+        for (const [name, enabled] of Object.entries(declared)) {
+          if (enabled === true) {
+            allowed.add(name)
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.debug(`Could not read allowScripts for ${pluginName}@${pluginVersion}: ${error.message}`)
+    }
+
+    return [...allowed]
   }
 
   /**

--- a/src/modules/plugins/plugins.service.ts
+++ b/src/modules/plugins/plugins.service.ts
@@ -2273,7 +2273,6 @@ export class PluginsService {
     const env = this.sanitizeNpmEnv(process.env)
     Object.assign(env, {
       npm_config_global_style: 'true',
-      npm_config_unsafe_perm: 'true',
       npm_config_update_notifier: 'false',
       npm_config_prefer_online: 'true',
       npm_config_foreground_scripts: 'true',

--- a/test/e2e/plugins.e2e-spec.ts
+++ b/test/e2e/plugins.e2e-spec.ts
@@ -14,6 +14,7 @@ import { ValidationPipe } from '@nestjs/common'
 import { FastifyAdapter } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import { copy, remove } from 'fs-extra'
+import { of } from 'rxjs'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AuthModule } from '../../src/core/auth/auth.module.js'
@@ -1345,6 +1346,82 @@ describe('PluginController (e2e)', () => {
       expect(typeof call[0]).toBe('string')
       expect(Array.isArray(call[1])).toBe(true)
       expect((call[2] as any)?.shell).not.toBe(true)
+    })
+  })
+
+  describe('getAllowedInstallScripts (#2909)', () => {
+    const call = (name: string, version: string) =>
+      (pluginsService as any).getAllowedInstallScripts(name, version) as Promise<string[]>
+
+    beforeEach(() => {
+      // Prime the cached npm major version so the tests never shell out.
+      ;(pluginsService as any).npmMajorVersion = 12
+    })
+
+    it('returns an empty list on npm older than 12 without hitting the registry', async () => {
+      ;(pluginsService as any).npmMajorVersion = 10
+      const getSpy = vi.spyOn(httpService, 'get')
+
+      await expect(call('homebridge-mock-plugin', '1.0.0')).resolves.toEqual([])
+      expect(getSpy).not.toHaveBeenCalled()
+      getSpy.mockRestore()
+    })
+
+    it('allows the plugin itself plus map-form allowScripts entries, keys verbatim', async () => {
+      const getSpy = vi.spyOn(httpService, 'get').mockReturnValue(of({
+        data: {
+          versions: {
+            '1.0.0': {
+              allowScripts: {
+                '@stoprocent/noble@2.3.4': true,
+                'ffmpeg-for-homebridge': true,
+                'blocked-package': false,
+              },
+            },
+          },
+        },
+      }) as any)
+
+      await expect(call('homebridge-mock-plugin', '1.0.0')).resolves.toEqual([
+        'homebridge-mock-plugin',
+        '@stoprocent/noble@2.3.4',
+        'ffmpeg-for-homebridge',
+      ])
+      getSpy.mockRestore()
+    })
+
+    it('allows array-form allowScripts entries', async () => {
+      const getSpy = vi.spyOn(httpService, 'get').mockReturnValue(of({
+        data: {
+          versions: {
+            '2.0.0': { allowScripts: ['ffmpeg-for-homebridge'] },
+          },
+        },
+      }) as any)
+
+      await expect(call('homebridge-mock-plugin', '2.0.0')).resolves.toEqual([
+        'homebridge-mock-plugin',
+        'ffmpeg-for-homebridge',
+      ])
+      getSpy.mockRestore()
+    })
+
+    it('still allows the plugin itself when it declares no allowScripts', async () => {
+      const getSpy = vi.spyOn(httpService, 'get').mockReturnValue(of({
+        data: { versions: { '1.0.0': {} } },
+      }) as any)
+
+      await expect(call('homebridge-mock-plugin', '1.0.0')).resolves.toEqual(['homebridge-mock-plugin'])
+      getSpy.mockRestore()
+    })
+
+    it('still allows the plugin itself when the registry lookup fails', async () => {
+      const getSpy = vi.spyOn(httpService, 'get').mockImplementation(() => {
+        throw new Error('registry unreachable')
+      })
+
+      await expect(call('homebridge-mock-plugin', '1.0.0')).resolves.toEqual(['homebridge-mock-plugin'])
+      getSpy.mockRestore()
     })
   })
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5462,9 +5462,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -5931,9 +5931,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7849,9 +7849,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -7869,7 +7869,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/src/app/core/accessories/accessories.interfaces.ts
+++ b/ui/src/app/core/accessories/accessories.interfaces.ts
@@ -177,6 +177,12 @@ export interface MatterTemperatureMeasurementCluster extends Record<string, unkn
   maxMeasuredValue?: number
 }
 
+export interface MatterElectricalPowerMeasurementCluster extends Record<string, unknown> {
+  voltage?: number | null // millivolts
+  activeCurrent?: number | null // milliamps
+  activePower?: number | null // milliwatts
+}
+
 /**
  * Matter RelativeHumidityMeasurement cluster attributes
  */
@@ -409,6 +415,7 @@ export interface MatterClusters extends Record<string, unknown> {
   thermostat?: MatterThermostatCluster
   switch?: MatterSwitchCluster
   valveConfigurationAndControl?: MatterValveConfigurationAndControlCluster
+  electricalPowerMeasurement?: MatterElectricalPowerMeasurementCluster
 }
 
 /**

--- a/ui/src/app/core/accessories/types/matter/matter-device.utils.ts
+++ b/ui/src/app/core/accessories/types/matter/matter-device.utils.ts
@@ -328,6 +328,18 @@ export function getLightSensorIlluminance(service: ServiceTypeX): number {
 }
 
 /**
+ * Get the active power reading (in watts)
+ * Matter stores ElectricalPowerMeasurement.activePower in milliwatts
+ */
+export function getActivePowerWatts(service: ServiceTypeX): number | null {
+  const activePower = service.clusters?.electricalPowerMeasurement?.activePower
+  if (activePower === null || activePower === undefined || typeof activePower !== 'number') {
+    return null
+  }
+  return activePower / 1000 // Convert from milliwatts to watts
+}
+
+/**
  * Get temperature sensor value (in °C)
  * Matter stores temperature in hundredths of °C
  */

--- a/ui/src/app/core/accessories/types/matter/on-off-plug-in-unit/on-off-plug-in-unit.component.html
+++ b/ui/src/app/core/accessories/types/matter/on-off-plug-in-unit/on-off-plug-in-unit.component.html
@@ -1,5 +1,7 @@
 @let on = isOn();
-@let stateText = on ? ('accessories.control.on' | translate) : ('accessories.control.off' | translate);
+@let watts = activePowerWatts();
+@let baseStateText = on ? ('accessories.control.on' | translate) : ('accessories.control.off' | translate);
+@let stateText = on && watts !== null ? `${baseStateText} · ${(watts | number: '1.0-1')}W` : baseStateText;
 
 @let srBaseName = (service().customName || service().serviceName || service().displayName || '').trim();
 @let srType = 'accessories.core.outlet' | translate;
@@ -68,10 +70,6 @@
     <div class="accessory-label mt-auto" aria-hidden="true">
       {{ service().customName || service().serviceName || service().displayName }}
     </div>
-    <div
-      class="accessory-label grey-text"
-      aria-hidden="true"
-      [innerText]="(on ? 'accessories.control.on' : 'accessories.control.off') | translate"
-    ></div>
+    <div class="accessory-label grey-text" aria-hidden="true" [innerText]="stateText"></div>
   </div>
 </div>

--- a/ui/src/app/core/accessories/types/matter/on-off-plug-in-unit/on-off-plug-in-unit.component.ts
+++ b/ui/src/app/core/accessories/types/matter/on-off-plug-in-unit/on-off-plug-in-unit.component.ts
@@ -1,14 +1,15 @@
-import { LowerCasePipe } from '@angular/common'
+import { DecimalPipe, LowerCasePipe } from '@angular/common'
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core'
 import { TranslatePipe } from '@ngx-translate/core'
 
 import { ServiceTypeX } from '@/app/core/accessories/accessories.interfaces'
-import { controlDevice, getDeviceActiveState } from '@/app/core/accessories/types/matter/matter-device.utils'
+import { controlDevice, getActivePowerWatts, getDeviceActiveState } from '@/app/core/accessories/types/matter/matter-device.utils'
 import { SettingsService } from '@/app/core/ui/settings.service'
 
 @Component({
   selector: 'app-on-off-plug-in-unit',
   imports: [
+    DecimalPipe,
     LowerCasePipe,
     TranslatePipe,
   ],
@@ -34,4 +35,8 @@ export class OnOffPlugInUnitComponent {
   }
 
   public readonly isOn = computed(() => getDeviceActiveState(this.service()))
+
+  // Live power reading in watts, or null when the outlet does not expose the
+  // ElectricalPowerMeasurement cluster (or has no reading yet)
+  public readonly activePowerWatts = computed(() => getActivePowerWatts(this.service()))
 }


### PR DESCRIPTION
### UI Changes

- feat(accessories): show live power on matter outlet tiles

### Other Changes

- chore(deps): dependency updates
- fix(plugins): drop the npm_config_unsafe_perm env var from npm spawns (#2891)
- feat(plugins): pass plugin-declared allow-scripts to npm 12 installs (#2909)

### Homebridge Dependencies

- `@homebridge/hap-client` @ `v5.1.0`
- `@homebridge/node-pty-prebuilt-multiarch` @ `v0.13.1`
- `@homebridge/plugin-ui-utils` @ `v2.2.5`