### PR TITLE
fix(ui): keep status widget values and units on one line

### DIFF
--- a/ui/src/scss/components/widgets.scss
+++ b/ui/src/scss/components/widgets.scss
@@ -18,6 +18,9 @@ gridster-preview {
     font-size: 2rem;
     font-weight: 300;
     line-height: 1.2;
+    // Keep value + unit on one line in narrow gridster cells (iOS Safari
+    // otherwise wraps at the space before units like "GB" / "Mb/s").
+    white-space: nowrap;
 
     @media (max-width: 1500px) {
       font-size: 1.75rem;


### PR DESCRIPTION
## Summary

Fixes the Status page Memory widget layout on narrow iOS Safari viewports (iPad/iPhone), where the unit wraps onto its own line:

```text
15.62
GB
```

Root cause is a breakable space between the formatted number and unit (`GB`, and similarly `Mb/s` on Network) inside a large-font flex cell — not a missing space. Copilot's earlier attempt in #2604 only adjusted spacing that was already present.

This adds `white-space: nowrap` on `.widget-value` so value + unit stay on one line for Memory, Network, and other status widgets sharing that class.

Fixes #2601

## Test plan

- [ ] Please wait for confirmation from @mafyata (issue reporter) on iPad/iPhone before merging
- [ ] Status → Memory widget: total/available show as `X.XX GB` on one line in portrait
- [ ] Status → Network widget: `Mb/s` values similarly do not wrap mid-unit
- [ ] Desktop layout unchanged