### PR TITLE
feat(settings): support HAP `disableIdentifyingMaterial` option

### DIFF
--- a/src/core/feature-flags/feature-flags.registry.ts
+++ b/src/core/feature-flags/feature-flags.registry.ts
@@ -69,4 +69,9 @@ export const FEATURE_FLAGS: FeatureFlagDefinition[] = [
     description: 'Exposes `matter.disableIpv4` (main bridge and child bridges). When true, the Matter mDNS responder runs IPv6-only — no IPv4 sockets on port 5353 — so it cannot compete with avahi-daemon for IPv4 mDNS traffic on the same host (symptom: `<hostname>.local` stops resolving over IPv4). Requires a homebridge runtime that reads the option; older runtimes ignore the key.',
     range: '>=2.2.0',
   },
+  {
+    key: 'hapDisableIdentifyingMaterial',
+    description: 'Exposes `hap.disableIdentifyingMaterial` (main bridge and child bridges). When true, HAP-NodeJS does not append username-derived identifying material to bridge display names and mDNS service instance names. Requires a homebridge runtime that reads the option; older runtimes reject the key.',
+    range: '>=2.2.2-beta.0',
+  },
 ]

--- a/src/core/matter/matter.interfaces.ts
+++ b/src/core/matter/matter.interfaces.ts
@@ -52,6 +52,14 @@ export interface BridgeHapConfig {
    * own standalone tile). Requires `enabled: false`.
    */
   externalsOnly?: boolean
+  /**
+   * Whether to disable HAP-NodeJS's `addIdentifyingMaterial` publish option,
+   * which appends identifying material derived from the username to the
+   * bridge display name and mDNS service instance name. Defaults to `false`.
+   * Only honoured by Homebridge >= 2.2.2-beta.0 (see the
+   * `hapDisableIdentifyingMaterial` feature flag).
+   */
+  disableIdentifyingMaterial?: boolean
 }
 
 // --- Accessories types ---

--- a/src/modules/config-editor/config-editor.controller.ts
+++ b/src/modules/config-editor/config-editor.controller.ts
@@ -368,8 +368,8 @@ export class ConfigEditorController {
 
   @UseGuards(AdminGuard)
   @ApiOperation({
-    summary: 'Get HAP enablement for the main bridge',
-    description: 'Returns whether HAP is published for the main Homebridge bridge. HAP is on by default. Reads tolerate both the legacy `bridge.hap: false` boolean form and the nested `bridge.hap: { enabled: false }` form used by Homebridge >= 2.0.3-beta.26.',
+    summary: 'Get HAP configuration for the main bridge',
+    description: 'Returns whether HAP is published for the main Homebridge bridge and the supported nested HAP options. HAP is on by default. Reads tolerate both the legacy `bridge.hap: false` boolean form and the nested object form used by newer Homebridge versions.',
   })
   @Get('/hap')
   getHapEnabled() {
@@ -378,12 +378,12 @@ export class ConfigEditorController {
 
   @UseGuards(AdminGuard)
   @ApiOperation({
-    summary: 'Enable or disable HAP for the main bridge',
-    description: 'Toggles HAP for the main Homebridge bridge. The shape written to `bridge.hap` depends on the `protocolExternalsOnly` feature flag: when the running Homebridge supports it the nested object form is written, otherwise the boolean form is preserved.',
+    summary: 'Update HAP configuration for the main bridge',
+    description: 'Updates HAP enablement and supported nested options for the main Homebridge bridge. The shape written to `bridge.hap` depends on feature support in the running Homebridge version.',
   })
-  @ApiBody({ description: 'HAP enablement', type: 'json' })
+  @ApiBody({ description: 'HAP configuration', type: 'json' })
   @Put('/hap')
-  setHapEnabled(@Body() body: { enabled: boolean, restart?: boolean, externalsOnly?: boolean }) {
-    return this.configEditorService.setHapEnabled(body.enabled, body.restart ?? true, body.externalsOnly ?? false)
+  setHapEnabled(@Body() body: { enabled: boolean, restart?: boolean, externalsOnly?: boolean, disableIdentifyingMaterial?: boolean }) {
+    return this.configEditorService.setHapEnabled(body.enabled, body.restart ?? true, body.externalsOnly ?? false, body.disableIdentifyingMaterial)
   }
 }

--- a/src/modules/config-editor/config-editor.service.ts
+++ b/src/modules/config-editor/config-editor.service.ts
@@ -1196,50 +1196,69 @@ export class ConfigEditorService implements OnApplicationBootstrap {
   }
 
   /**
-   * Get whether HAP is enabled on the main bridge, plus the externalsOnly
-   * flag for newer Homebridge versions.
+   * Get whether HAP is enabled on the main bridge, plus nested HAP options
+   * supported by newer Homebridge versions.
    *
    * HAP is enabled by default; users opt out via either the legacy boolean
    * form (`bridge.hap: false`, older Homebridge) or the nested form
-   * (`bridge.hap: { enabled: false, externalsOnly?: true }`, Homebridge >= 2.0.3-beta.26).
+   * (`bridge.hap: { enabled: false, externalsOnly?: true,
+   * disableIdentifyingMaterial?: true }`, newer Homebridge versions).
    * Reading tolerates both shapes; writing chooses the appropriate shape
-   * based on the `protocolExternalsOnly` feature flag.
+   * based on the applicable feature flags.
    */
-  public async getHapEnabled(): Promise<{ enabled: boolean, externalsOnly: boolean }> {
+  public async getHapEnabled(): Promise<{ enabled: boolean, externalsOnly: boolean, disableIdentifyingMaterial: boolean }> {
     const config = await this.getConfigFile()
     const hap = config.bridge?.hap
     // Legacy: hap === false means disabled.
     if (hap === false) {
-      return { enabled: false, externalsOnly: false }
+      return { enabled: false, externalsOnly: false, disableIdentifyingMaterial: false }
     }
-    // Nested: { enabled: false } means disabled, optionally externalsOnly.
+    // Nested: { enabled: false } means disabled; other options are surfaced
+    // independently of the running version so manually-authored configs remain visible.
     if (typeof hap === 'object' && hap !== null) {
       const enabled = hap.enabled !== false
       const externalsOnly = hap.externalsOnly === true
-      return { enabled, externalsOnly }
+      const disableIdentifyingMaterial = hap.disableIdentifyingMaterial === true
+      return { enabled, externalsOnly, disableIdentifyingMaterial }
     }
-    return { enabled: true, externalsOnly: false }
+    return { enabled: true, externalsOnly: false, disableIdentifyingMaterial: false }
   }
 
   /**
    * Enable or disable HAP on the main bridge.
    *
    * Writes either the boolean form or the nested object form based on the
-   * `protocolExternalsOnly` feature flag (which depends on the running
-   * Homebridge version). When disabling, the optional `externalsOnly` flag
-   * is honoured only when the nested shape is being written.
+   * running Homebridge version. When disabling, the optional `externalsOnly`
+   * flag is honoured only when supported. `disableIdentifyingMaterial` is
+   * preserved when older UI clients omit it from a HAP enablement request.
    *
    * @param enabled - Whether HAP should be published.
    * @param restart - Whether to restart Homebridge after the change (deferred to caller when false).
    * @param externalsOnly - Optional. When `enabled: false`, additionally suppress the bridge accessory itself (externals still publish).
+   * @param disableIdentifyingMaterial - Optional. Whether HAP-NodeJS should omit username-derived identifying material from published names.
    */
   public async setHapEnabled(
     enabled: boolean,
     restart = true,
     externalsOnly = false,
-  ): Promise<{ enabled: boolean, externalsOnly: boolean }> {
+    disableIdentifyingMaterial?: boolean,
+  ): Promise<{ enabled: boolean, externalsOnly: boolean, disableIdentifyingMaterial: boolean }> {
+    if (disableIdentifyingMaterial !== undefined && typeof disableIdentifyingMaterial !== 'boolean') {
+      throw new BadRequestException('HAP disableIdentifyingMaterial must be a boolean.')
+    }
+
     const config = await this.getConfigFile()
-    const useNestedShape = this.configService.getFeatureFlags().protocolExternalsOnly === true
+    const featureFlags = this.configService.getFeatureFlags()
+    const supportsExternalsOnly = featureFlags.protocolExternalsOnly === true
+    const supportsDisableIdentifyingMaterial = featureFlags.hapDisableIdentifyingMaterial === true
+    const useNestedShape = supportsExternalsOnly || supportsDisableIdentifyingMaterial
+    const currentHap = config.bridge?.hap
+    const currentDisableIdentifyingMaterial = typeof currentHap === 'object'
+      && currentHap !== null
+      && currentHap.disableIdentifyingMaterial === true
+    const targetDisableIdentifyingMaterial = supportsDisableIdentifyingMaterial
+      && (disableIdentifyingMaterial ?? currentDisableIdentifyingMaterial)
+    const targetExternalsOnly = supportsExternalsOnly && !enabled && externalsOnly
 
     if (!enabled) {
       // Shutdown first so the running server doesn't see a partial config, unless
@@ -1248,25 +1267,33 @@ export class ConfigEditorService implements OnApplicationBootstrap {
         await this.homebridgeIpcService.restartAndWaitForClose()
       }
       if (useNestedShape) {
-        config.bridge.hap = externalsOnly
-          ? { enabled: false, externalsOnly: true }
-          : { enabled: false }
+        config.bridge.hap = {
+          enabled: false,
+          ...(targetExternalsOnly ? { externalsOnly: true } : {}),
+          ...(targetDisableIdentifyingMaterial ? { disableIdentifyingMaterial: true } : {}),
+        }
       } else {
         // Legacy runtime: externalsOnly is ignored (the runtime would reject the nested form).
         config.bridge.hap = false
       }
       await this.updateConfigFile(config)
     } else {
-      // Re-enable: drop the property entirely so the default (enabled) takes effect.
-      // Any present shape — the legacy boolean or any nested object — is removed,
-      // which also clears a lingering externalsOnly that would otherwise fail validation.
-      const hap = config.bridge?.hap
-      if (hap === false || (typeof hap === 'object' && hap !== null)) {
+      // Re-enable: clear enabled/externalsOnly while retaining the identifying
+      // material preference. If it is off, drop the property entirely so the
+      // default HAP behavior takes effect.
+      if (targetDisableIdentifyingMaterial) {
+        config.bridge.hap = { disableIdentifyingMaterial: true }
+        await this.updateConfigFile(config)
+      } else if (currentHap === false || (typeof currentHap === 'object' && currentHap !== null)) {
         delete config.bridge.hap
         await this.updateConfigFile(config)
       }
     }
-    return { enabled, externalsOnly: useNestedShape && !enabled && externalsOnly }
+    return {
+      enabled,
+      externalsOnly: targetExternalsOnly,
+      disableIdentifyingMaterial: targetDisableIdentifyingMaterial,
+    }
   }
 
   /**

--- a/test/e2e/config-editor.e2e-spec.ts
+++ b/test/e2e/config-editor.e2e-spec.ts
@@ -45,6 +45,8 @@ describe('ConfigEditorController (e2e)', () => {
   let schedulerService: SchedulerService
   let configEditorService: ConfigEditorService
   let backupService: BackupService
+  let homebridgeConfigService: ConfigService
+  let originalHomebridgeVersion: string
 
   beforeAll(async () => {
     process.env.UIX_BASE_PATH = resolve(__dirname, '../../')
@@ -86,12 +88,16 @@ describe('ConfigEditorController (e2e)', () => {
     schedulerService = app.get(SchedulerService)
     configEditorService = app.get(ConfigEditorService)
     backupService = app.get(BackupService)
+    homebridgeConfigService = app.get(ConfigService)
+    originalHomebridgeVersion = homebridgeConfigService.homebridgeVersion
 
     // Wait for initial paths to be setup
     await new Promise(res => setTimeout(res, 1000))
   })
 
   beforeEach(async () => {
+    homebridgeConfigService.homebridgeVersion = originalHomebridgeVersion
+
     // Get auth token before each test
     authorization = `bearer ${(await app.inject({
       method: 'POST',
@@ -1997,7 +2003,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
   })
 
   it('GET /config-editor/hap (should return enabled=false when bridge.hap=false, legacy boolean form)', async () => {
@@ -2016,7 +2022,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: false, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: false, disableIdentifyingMaterial: false })
   })
 
   it('GET /config-editor/hap (should return enabled=true when bridge.hap=true explicitly)', async () => {
@@ -2033,7 +2039,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
   })
 
   it('GET /config-editor/hap (should return enabled=false when bridge.hap is the nested object form)', async () => {
@@ -2053,7 +2059,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: false, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: false, disableIdentifyingMaterial: false })
   })
 
   it('GET /config-editor/hap (should surface externalsOnly:true when set in the nested form)', async () => {
@@ -2070,7 +2076,24 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: false, externalsOnly: true })
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: true, disableIdentifyingMaterial: false })
+  })
+
+  it('GET /config-editor/hap (should surface disableIdentifyingMaterial:true when set)', async () => {
+    const config: HomebridgeConfig = await readJson(configFilePath)
+    config.bridge.hap = { disableIdentifyingMaterial: true }
+    await writeJson(configFilePath, config)
+
+    const res = await app.inject({
+      method: 'GET',
+      path: '/config-editor/hap',
+      headers: {
+        authorization,
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: true })
   })
 
   it('GET /config-editor/hap (should treat an empty hap object as enabled)', async () => {
@@ -2087,7 +2110,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
   })
 
   it('PUT /config-editor/hap (should allow disabling HAP even when Matter is not configured)', async () => {
@@ -2104,7 +2127,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: false, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: false, disableIdentifyingMaterial: false })
 
     // bridge.hap should be persisted as false (legacy form on the older mock
     // homebridge version that doesn't have the protocolExternalsOnly flag).
@@ -2134,7 +2157,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: false, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: false, disableIdentifyingMaterial: false })
 
     const config: HomebridgeConfig = await readJson(configFilePath)
     expect(config.bridge.hap).toBe(false)
@@ -2158,7 +2181,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
 
     // hap property should be removed (HAP enabled is the default — omit when on)
     const updated: HomebridgeConfig = await readJson(configFilePath)
@@ -2181,7 +2204,7 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
 
     // The whole property is dropped — externalsOnly: true cannot coexist with enabled: true.
     const updated: HomebridgeConfig = await readJson(configFilePath)
@@ -2203,10 +2226,89 @@ describe('ConfigEditorController (e2e)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ enabled: true, externalsOnly: false })
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
 
     const after: HomebridgeConfig = await readJson(configFilePath)
     expect(after.bridge.hap).toBeUndefined()
+  })
+
+  it('should enable the hapDisableIdentifyingMaterial feature flag from Homebridge 2.2.2-beta.0', () => {
+    homebridgeConfigService.homebridgeVersion = '2.2.1'
+    expect(homebridgeConfigService.getFeatureFlags().hapDisableIdentifyingMaterial).toBe(false)
+
+    homebridgeConfigService.homebridgeVersion = '2.2.2-beta.0'
+    expect(homebridgeConfigService.getFeatureFlags().hapDisableIdentifyingMaterial).toBe(true)
+
+    homebridgeConfigService.homebridgeVersion = '2.3.0'
+    expect(homebridgeConfigService.getFeatureFlags().hapDisableIdentifyingMaterial).toBe(true)
+  })
+
+  it('PUT /config-editor/hap (should persist and preserve disableIdentifyingMaterial)', async () => {
+    homebridgeConfigService.homebridgeVersion = '2.2.2-beta.0'
+
+    let res = await app.inject({
+      method: 'PUT',
+      path: '/config-editor/hap',
+      headers: { authorization },
+      payload: { enabled: true, disableIdentifyingMaterial: true, restart: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: true })
+    let config: HomebridgeConfig = await readJson(configFilePath)
+    expect(config.bridge.hap).toEqual({ disableIdentifyingMaterial: true })
+
+    // Older UI clients omit the new field when toggling HAP. Preserve the
+    // configured preference across both transitions.
+    res = await app.inject({
+      method: 'PUT',
+      path: '/config-editor/hap',
+      headers: { authorization },
+      payload: { enabled: false, restart: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ enabled: false, externalsOnly: false, disableIdentifyingMaterial: true })
+    config = await readJson(configFilePath)
+    expect(config.bridge.hap).toEqual({ enabled: false, disableIdentifyingMaterial: true })
+
+    res = await app.inject({
+      method: 'PUT',
+      path: '/config-editor/hap',
+      headers: { authorization },
+      payload: { enabled: true, restart: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: true })
+    config = await readJson(configFilePath)
+    expect(config.bridge.hap).toEqual({ disableIdentifyingMaterial: true })
+
+    res = await app.inject({
+      method: 'PUT',
+      path: '/config-editor/hap',
+      headers: { authorization },
+      payload: { enabled: true, disableIdentifyingMaterial: false, restart: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ enabled: true, externalsOnly: false, disableIdentifyingMaterial: false })
+    config = await readJson(configFilePath)
+    expect(config.bridge.hap).toBeUndefined()
+  })
+
+  it('PUT /config-editor/hap (should reject non-boolean disableIdentifyingMaterial)', async () => {
+    homebridgeConfigService.homebridgeVersion = '2.2.2-beta.0'
+
+    const res = await app.inject({
+      method: 'PUT',
+      path: '/config-editor/hap',
+      headers: { authorization },
+      payload: { enabled: true, disableIdentifyingMaterial: 'yes', restart: false },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toContain('disableIdentifyingMaterial must be a boolean')
   })
 
   it('GET/PUT /config-editor/ui/bridges/:username/scheduled-restart-cron (should handle scheduled restart cron)', async () => {

--- a/ui/src/app/core/helpers/child-bridges-schema.helper.ts
+++ b/ui/src/app/core/helpers/child-bridges-schema.helper.ts
@@ -19,6 +19,11 @@ export interface ChildBridgeSchemaOptions {
    * that makes the Matter mDNS responder IPv6-only.
    */
   isMatterDisableIpv4Enabled?: boolean
+  /**
+   * When true (Homebridge >= 2.2.2-beta.0), `hap` accepts a
+   * `disableIdentifyingMaterial` flag.
+   */
+  isHapDisableIdentifyingMaterialEnabled?: boolean
 }
 
 /**
@@ -30,9 +35,10 @@ export interface ChildBridgeSchemaOptions {
  * @param options.isPlatformPlugin - Whether the plugin is platform-based (Matter only works with platform plugins)
  * @param options.isProtocolExternalsOnlyEnabled - Whether the running Homebridge supports the nested HAP shape and externalsOnly mode
  * @param options.isMatterDisableIpv4Enabled - Whether the running Homebridge supports the Matter disableIpv4 option
+ * @param options.isHapDisableIdentifyingMaterialEnabled - Whether the running Homebridge supports the HAP disableIdentifyingMaterial option
  * @returns Child bridge schema object
  */
-export function createChildBridgeSchema(translate: TranslateService, { isDebugModeEnabled, isMatterSupported, isPlatformPlugin = true, isProtocolExternalsOnlyEnabled = false, isMatterDisableIpv4Enabled = false }: ChildBridgeSchemaOptions) {
+export function createChildBridgeSchema(translate: TranslateService, { isDebugModeEnabled, isMatterSupported, isPlatformPlugin = true, isProtocolExternalsOnlyEnabled = false, isMatterDisableIpv4Enabled = false, isHapDisableIdentifyingMaterialEnabled = false }: ChildBridgeSchemaOptions) {
   return {
     type: 'object',
     required: ['username'],
@@ -93,7 +99,7 @@ export function createChildBridgeSchema(translate: TranslateService, { isDebugMo
             },
           }
         : {},
-      hap: createHapSchema(translate, isProtocolExternalsOnlyEnabled, 'child'),
+      hap: createHapSchema(translate, isProtocolExternalsOnlyEnabled, 'child', isHapDisableIdentifyingMaterialEnabled),
       env: {
         type: 'object',
         additionalProperties: false,

--- a/ui/src/app/core/helpers/hap-schema.helper.ts
+++ b/ui/src/app/core/helpers/hap-schema.helper.ts
@@ -5,22 +5,27 @@ import { TranslateService } from '@ngx-translate/core'
  * bridge schema (config-editor) and the child bridge schema so the two cannot
  * drift apart.
  *
- * When externalsOnly is supported (Homebridge >= 2.0.3-beta.26) the field
- * accepts both the nested object form `{ enabled?, externalsOnly? }` and the
- * legacy boolean — so configs written by older UI versions (or against older
- * runtimes) stay valid. Otherwise it is a plain boolean.
+ * When nested HAP options are supported, the field accepts both the nested
+ * object form and the legacy boolean — so configs written by older UI versions
+ * (or against older runtimes) stay valid. Otherwise it is a plain boolean.
  *
  * @param translate - The translation service for localized titles
  * @param isProtocolExternalsOnlyEnabled - Whether the running Homebridge supports the nested HAP shape and externalsOnly mode
  * @param scope - `'main'` for the main bridge or `'child'` for a child bridge; selects the description wording
+ * @param isHapDisableIdentifyingMaterialEnabled - Whether the running Homebridge supports the HAP disableIdentifyingMaterial option
  * @returns The JSON schema fragment for the `hap` property
  */
-export function createHapSchema(translate: TranslateService, isProtocolExternalsOnlyEnabled: boolean, scope: 'child' | 'main') {
+export function createHapSchema(
+  translate: TranslateService,
+  isProtocolExternalsOnlyEnabled: boolean,
+  scope: 'child' | 'main',
+  isHapDisableIdentifyingMaterialEnabled = false,
+) {
   const disabledDescription = scope === 'main'
     ? 'When false, HAP is not advertised for the main bridge.'
     : 'When false, HAP is not advertised for this child bridge.'
 
-  if (!isProtocolExternalsOnlyEnabled) {
+  if (!isProtocolExternalsOnlyEnabled && !isHapDisableIdentifyingMaterialEnabled) {
     return {
       type: 'boolean',
       title: translate.instant('child_bridge.config.enable_hap'),
@@ -42,11 +47,24 @@ export function createHapSchema(translate: TranslateService, isProtocolExternals
             title: translate.instant('child_bridge.config.enable_hap'),
             description: disabledDescription,
           },
-          externalsOnly: {
-            type: 'boolean',
-            title: translate.instant('child_bridge.config.hap_externals_only'),
-            description: 'When true, the bridge accessory itself is not published but plugins may still publish external HAP accessories. Requires hap.enabled: false.',
-          },
+          ...(isProtocolExternalsOnlyEnabled
+            ? {
+                externalsOnly: {
+                  type: 'boolean',
+                  title: translate.instant('child_bridge.config.hap_externals_only'),
+                  description: 'When true, the bridge accessory itself is not published but plugins may still publish external HAP accessories. Requires hap.enabled: false.',
+                },
+              }
+            : {}),
+          ...(isHapDisableIdentifyingMaterialEnabled
+            ? {
+                disableIdentifyingMaterial: {
+                  type: 'boolean',
+                  title: translate.instant('settings.hap.disable_identifying_material'),
+                  description: translate.instant('settings.hap.disable_identifying_material_desc'),
+                },
+              }
+            : {}),
         },
       },
     ],

--- a/ui/src/app/core/plugins/manage-plugins.interfaces.ts
+++ b/ui/src/app/core/plugins/manage-plugins.interfaces.ts
@@ -70,10 +70,10 @@ export interface ChildBridge {
   username: string
   /**
    * HAP config. Older Homebridge sends a boolean; >= 2.0.3-beta.26 sends the
-   * nested object form. Both shapes are typed so the UI can read either —
-   * `protocolExternalsOnly` feature flag determines which is authoritative.
+   * nested object form. Both shapes are typed so the UI can read either;
+   * feature flags determine which nested properties are available.
    */
-  hap?: boolean | { enabled?: boolean, externalsOnly?: boolean }
+  hap?: boolean | { enabled?: boolean, externalsOnly?: boolean, disableIdentifyingMaterial?: boolean }
   matterConfig?: {
     port?: number
     enabled?: boolean

--- a/ui/src/app/core/plugins/manual-config/manual-config.component.ts
+++ b/ui/src/app/core/plugins/manual-config/manual-config.component.ts
@@ -77,6 +77,7 @@ export class ManualConfigComponent implements OnInit, OnDestroy {
   private isMatterSupported = this.$settings.isFeatureEnabled('matterSupport')
   private isProtocolExternalsOnlyEnabled = this.$settings.isFeatureEnabled('protocolExternalsOnly')
   private isMatterDisableIpv4Enabled = this.$settings.isFeatureEnabled('matterDisableIpv4')
+  private isHapDisableIdentifyingMaterialEnabled = this.$settings.isFeatureEnabled('hapDisableIdentifyingMaterial')
 
   public readonly pluginAlias = signal<string>('')
   public readonly pluginType = signal<'platform' | 'accessory' | null>(null)
@@ -301,6 +302,7 @@ export class ManualConfigComponent implements OnInit, OnDestroy {
       isPlatformPlugin: this.pluginType() === 'platform',
       isProtocolExternalsOnlyEnabled: this.isProtocolExternalsOnlyEnabled,
       isMatterDisableIpv4Enabled: this.isMatterDisableIpv4Enabled,
+      isHapDisableIdentifyingMaterialEnabled: this.isHapDisableIdentifyingMaterialEnabled,
     })
 
     // Ensure required properties are present for the plugin type
@@ -381,6 +383,7 @@ export class ManualConfigComponent implements OnInit, OnDestroy {
       isPlatformPlugin: this.pluginType() === 'platform',
       isProtocolExternalsOnlyEnabled: this.isProtocolExternalsOnlyEnabled,
       isMatterDisableIpv4Enabled: this.isMatterDisableIpv4Enabled,
+      isHapDisableIdentifyingMaterialEnabled: this.isHapDisableIdentifyingMaterialEnabled,
     })
 
     if (this.pluginType() === 'platform') {

--- a/ui/src/app/core/plugins/plugin-bridge/plugin-bridge.component.html
+++ b/ui/src/app/core/plugins/plugin-bridge/plugin-bridge.component.html
@@ -444,6 +444,47 @@
               </li>
             }
 
+            <!--
+              HAP disableIdentifyingMaterial toggle — visible on Homebridge
+              >= 2.2.2-beta.0 for both platform and accessory child bridges.
+              It remains available while HAP is disabled so the preference is
+              preserved independently of protocol enablement.
+            -->
+            @if (isHapDisableIdentifyingMaterialEnabled) {
+              <li class="list-group-item d-flex justify-content-between align-items-center flex-row pb-2">
+                <span class="text-start d-flex align-items-center flex-grow-1 me-3">
+                  <i
+                    aria-hidden="true"
+                    class="fas fa-xl fa-hap me-2 my-2"
+                    [class.text-warning]="hapDisableIdentifyingMaterialBlocks()[+selectedBlock()]"
+                    [class.grey-text]="!hapDisableIdentifyingMaterialBlocks()[+selectedBlock()]"
+                  ></i>
+                  <span>
+                    {{ 'settings.hap.disable_identifying_material' | translate }}
+                    <span class="badge badge-primary ms-1">{{ 'common.labels.beta' | translate }}</span>
+                    <span class="d-block small grey-text">
+                      {{ 'settings.hap.disable_identifying_material_desc' | translate }}
+                    </span>
+                  </span>
+                </span>
+                <div class="text-end grey-text d-flex align-items-center">
+                  <input
+                    type="checkbox"
+                    class="rendux-input"
+                    [id]="`toggleHapDisableIdentifyingMaterialInput_${selectedBlock()}`"
+                    [checked]="hapDisableIdentifyingMaterialBlocks()[+selectedBlock()]"
+                    [attr.aria-label]="'settings.hap.disable_identifying_material' | translate"
+                    (change)="toggleHapDisableIdentifyingMaterial($event, +selectedBlock())"
+                  />
+                  <label
+                    class="rendux-label"
+                    aria-hidden="true"
+                    [for]="`toggleHapDisableIdentifyingMaterialInput_${selectedBlock()}`"
+                  ></label>
+                </div>
+              </li>
+            }
+
             @if (hapEnabledBlocks()[+selectedBlock()]) {
               <!-- HAP QR Code -->
               @if (

--- a/ui/src/app/core/plugins/plugin-bridge/plugin-bridge.component.ts
+++ b/ui/src/app/core/plugins/plugin-bridge/plugin-bridge.component.ts
@@ -111,6 +111,11 @@ export class PluginBridgeComponent implements OnInit {
   // Tracks whether HAP externalsOnly is set, keyed by block index. Only meaningful
   // when isProtocolExternalsOnlyEnabled is true and HAP is disabled for the block.
   public readonly hapExternalsOnlyBlocks = signal<Record<number, boolean>>({})
+  // When true (Homebridge >= 2.2.2-beta.0), HAP exposes a toggle that disables
+  // username-derived identifying material in bridge and mDNS service names.
+  public isHapDisableIdentifyingMaterialEnabled = this.$settings.isFeatureEnabled('hapDisableIdentifyingMaterial')
+  // Tracks whether HAP disableIdentifyingMaterial is set, keyed by block index.
+  public readonly hapDisableIdentifyingMaterialBlocks = signal<Record<number, boolean>>({})
   // Tracks whether Matter externalsOnly is set, keyed by block index. Only meaningful
   // when isProtocolExternalsOnlyEnabled is true and Matter is disabled for the block.
   public readonly matterExternalsOnlyBlocks = signal<Record<number, boolean>>({})
@@ -258,7 +263,8 @@ export class PluginBridgeComponent implements OnInit {
           //   - Nested object: `_bridge.hap.enabled === false` means disabled,
           //     and `_bridge.hap.externalsOnly === true` is also surfaced.
           // Accessory child bridges cannot disable HAP (no Matter alternative)
-          // and never have externalsOnly meaning.
+          // and never have externalsOnly meaning. They may still customize
+          // identifying material through the nested HAP object.
           const hap = block._bridge.hap
           let hapEnabled = true
           let hapExternalsOnly = false
@@ -273,6 +279,12 @@ export class PluginBridgeComponent implements OnInit {
           this.hapEnabledBlocks.update(current => ({ ...current, [i]: hapEnabled }))
           if (this.isProtocolExternalsOnlyEnabled) {
             this.hapExternalsOnlyBlocks.update(current => ({ ...current, [i]: hapExternalsOnly }))
+          }
+          if (this.isHapDisableIdentifyingMaterialEnabled) {
+            this.hapDisableIdentifyingMaterialBlocks.update(current => ({
+              ...current,
+              [i]: typeof hap === 'object' && hap !== null && hap.disableIdentifyingMaterial === true,
+            }))
           }
         }
 
@@ -397,6 +409,10 @@ export class PluginBridgeComponent implements OnInit {
     if (enable) {
       const bridgeCache = this.bridgeCache().get(Number(index))
       const matterCache = this.matterBridgeCache().get(Number(index))
+      const keepHapDisableIdentifyingMaterial = this.isHapDisableIdentifyingMaterialEnabled
+        && typeof bridgeCache?.hap === 'object'
+        && bridgeCache.hap !== null
+        && bridgeCache.hap.disableIdentifyingMaterial === true
 
       // Always create HAP bridge configuration when HAP toggle is enabled
       block._bridge = {
@@ -408,6 +424,7 @@ export class PluginBridgeComponent implements OnInit {
         firmwareRevision: bridgeCache?.firmwareRevision,
         debugModeEnabled: bridgeCache?.debugModeEnabled,
         env: bridgeCache?.env || {},
+        ...(keepHapDisableIdentifyingMaterial ? { hap: { disableIdentifyingMaterial: true } } : {}),
       }
 
       // Restore Matter configuration if it was previously cached (cached means it was enabled before disabling)
@@ -465,6 +482,12 @@ export class PluginBridgeComponent implements OnInit {
 
       // HAP defaults to on whenever a child bridge is enabled
       this.hapEnabledBlocks.update(current => ({ ...current, [Number(index)]: true }))
+      if (this.isHapDisableIdentifyingMaterialEnabled) {
+        this.hapDisableIdentifyingMaterialBlocks.update(current => ({
+          ...current,
+          [Number(index)]: keepHapDisableIdentifyingMaterial,
+        }))
+      }
     } else {
       // Set enabled state to false
       this.enabledBlocks.update(current => ({ ...current, [Number(index)]: false }))
@@ -825,6 +848,8 @@ export class PluginBridgeComponent implements OnInit {
     }
 
     if (enable) {
+      const keepDisableIdentifyingMaterial = this.isHapDisableIdentifyingMaterialEnabled
+        && this.hapDisableIdentifyingMaterialBlocks()[idx] === true
       this.hapEnabledBlocks.update(current => ({ ...current, [idx]: true }))
       // Re-enabling HAP must also clear any lingering externalsOnly setting —
       // the validation rule on the new runtime is `externalsOnly requires
@@ -848,14 +873,18 @@ export class PluginBridgeComponent implements OnInit {
         block._bridge.name = this.sanitizeBridgeName(this.plugin.displayName || this.plugin.name)
       }
 
-      delete block._bridge.hap
+      if (keepDisableIdentifyingMaterial) {
+        block._bridge.hap = { disableIdentifyingMaterial: true }
+      } else {
+        delete block._bridge.hap
+      }
 
       this.bridgeCache.update(current => new Map(current).set(idx, block._bridge))
       await this.getDeviceInfo(block._bridge.username)
     } else {
       this.hapEnabledBlocks.update(current => ({ ...current, [idx]: false }))
       block._bridge = block._bridge || {}
-      this.writeHapDisabled(block)
+      this.writeHapDisabled(block, idx)
     }
   }
 
@@ -867,11 +896,17 @@ export class PluginBridgeComponent implements OnInit {
    * gets written. externalsOnly is never set here — disabling HAP transitions
    * the block to the plain disabled shape, and the externalsOnly toggle (which
    * only appears once HAP is disabled) writes the externalsOnly shape itself
-   * via toggleHapExternalsOnly().
+   * via toggleHapExternalsOnly(). The independent disableIdentifyingMaterial
+   * preference is preserved in either nested disabled shape.
    */
-  private writeHapDisabled(block: any): void {
-    if (this.isProtocolExternalsOnlyEnabled) {
-      block._bridge.hap = { enabled: false }
+  private writeHapDisabled(block: any, idx: number): void {
+    if (this.isProtocolExternalsOnlyEnabled || this.isHapDisableIdentifyingMaterialEnabled) {
+      block._bridge.hap = {
+        enabled: false,
+        ...(this.hapDisableIdentifyingMaterialBlocks()[idx] === true
+          ? { disableIdentifyingMaterial: true }
+          : {}),
+      }
     } else {
       block._bridge.hap = false
     }
@@ -895,9 +930,51 @@ export class PluginBridgeComponent implements OnInit {
     // externalsOnly is only valid when HAP is disabled; write the nested
     // object form with the current toggle state.
     if (this.hapEnabledBlocks()[idx] === false) {
-      block._bridge.hap = checked
-        ? { enabled: false, externalsOnly: true }
-        : { enabled: false }
+      block._bridge.hap = {
+        enabled: false,
+        ...(checked ? { externalsOnly: true } : {}),
+        ...(this.hapDisableIdentifyingMaterialBlocks()[idx] === true
+          ? { disableIdentifyingMaterial: true }
+          : {}),
+      }
+    }
+  }
+
+  /**
+   * Toggle the `hap.disableIdentifyingMaterial` flag for a block. The option
+   * is independent of HAP enablement and is preserved across HAP and child
+   * bridge disable/enable round-trips.
+   */
+  public toggleHapDisableIdentifyingMaterial(event: Event, idx: number): void {
+    if (!this.isHapDisableIdentifyingMaterialEnabled) {
+      return
+    }
+    const checked = (event.target as HTMLInputElement).checked
+    const block = this.configBlocks()[idx]
+
+    this.hapDisableIdentifyingMaterialBlocks.update(current => ({ ...current, [idx]: checked }))
+
+    if (!block?._bridge) {
+      return
+    }
+
+    const existingHap = block._bridge.hap
+    const hap = typeof existingHap === 'object' && existingHap !== null
+      ? { ...existingHap }
+      : existingHap === false || this.hapEnabledBlocks()[idx] === false
+        ? { enabled: false }
+        : {}
+
+    if (checked) {
+      hap.disableIdentifyingMaterial = true
+    } else {
+      delete hap.disableIdentifyingMaterial
+    }
+
+    if (Object.keys(hap).length > 0) {
+      block._bridge.hap = hap
+    } else {
+      delete block._bridge.hap
     }
   }
 
@@ -1082,20 +1159,29 @@ export class PluginBridgeComponent implements OnInit {
     }
   }
 
-  private normalizeHapConfig(block: any, hapEnabled: boolean | undefined, hapExternalsOnly = false): void {
+  private normalizeHapConfig(
+    block: any,
+    hapEnabled: boolean | undefined,
+    hapExternalsOnly = false,
+    hapDisableIdentifyingMaterial = false,
+  ): void {
     if (!block._bridge) {
       return
     }
     if (hapEnabled === false) {
-      if (this.isProtocolExternalsOnlyEnabled) {
-        // Nested form for Homebridge >= 2.0.3-beta.26. externalsOnly is only
-        // written when explicitly toggled on alongside enabled: false.
-        block._bridge.hap = hapExternalsOnly
-          ? { enabled: false, externalsOnly: true }
-          : { enabled: false }
+      if (this.isProtocolExternalsOnlyEnabled || this.isHapDisableIdentifyingMaterialEnabled) {
+        // Nested form for newer Homebridge versions. Optional settings are
+        // written only when explicitly toggled on.
+        block._bridge.hap = {
+          enabled: false,
+          ...(hapExternalsOnly ? { externalsOnly: true } : {}),
+          ...(hapDisableIdentifyingMaterial ? { disableIdentifyingMaterial: true } : {}),
+        }
       } else {
         block._bridge.hap = false
       }
+    } else if (hapDisableIdentifyingMaterial) {
+      block._bridge.hap = { disableIdentifyingMaterial: true }
     } else {
       delete block._bridge.hap
     }
@@ -1185,13 +1271,15 @@ export class PluginBridgeComponent implements OnInit {
         // Normalize the matter config (trim strings, remove empty values)
         this.normalizeMatterConfig(block)
 
-        // Normalize the hap flag — only persist `false` (or `{ enabled: false }`
-        // on the new runtime); omit when on. externalsOnly carries through
-        // only when HAP is disabled.
+        // Normalize HAP into the shape supported by the running Homebridge.
+        // externalsOnly carries through only when HAP is disabled; the
+        // identifying-material preference is independent of enablement.
         const hapExternalsOnly = this.isProtocolExternalsOnlyEnabled
           && hapEnabledBlocks[index] === false
           && this.hapExternalsOnlyBlocks()[index] === true
-        this.normalizeHapConfig(block, hapEnabledBlocks[index], hapExternalsOnly)
+        const hapDisableIdentifyingMaterial = this.isHapDisableIdentifyingMaterialEnabled
+          && this.hapDisableIdentifyingMaterialBlocks()[index] === true
+        this.normalizeHapConfig(block, hapEnabledBlocks[index], hapExternalsOnly, hapDisableIdentifyingMaterial)
       }
 
       await this.$api.post(`/config-editor/plugin/${encodeURIComponent(plugin.name)}`, configBlocks)
@@ -1571,13 +1659,17 @@ export class PluginBridgeComponent implements OnInit {
 
       // Check HAP disabled state. Both shapes are tolerated:
       // legacy boolean (`hap === false`) and nested object (`hap.enabled === false`).
-      // externalsOnly is also part of the persisted state.
+      // Nested HAP options are also part of the persisted state.
       const isHapDisabled = (h: any) => h === false || (typeof h === 'object' && h !== null && h.enabled === false)
       const hapExternalsOnly = (h: any) => typeof h === 'object' && h !== null && h.externalsOnly === true
+      const hapDisableIdentifyingMaterial = (h: any) => typeof h === 'object' && h !== null && h.disableIdentifyingMaterial === true
       if (isHapDisabled(block._bridge.hap) !== isHapDisabled(original.hap)) {
         return true
       }
       if (hapExternalsOnly(block._bridge.hap) !== hapExternalsOnly(original.hap)) {
+        return true
+      }
+      if (hapDisableIdentifyingMaterial(block._bridge.hap) !== hapDisableIdentifyingMaterial(original.hap)) {
         return true
       }
 

--- a/ui/src/app/core/server.interfaces.ts
+++ b/ui/src/app/core/server.interfaces.ts
@@ -76,12 +76,12 @@ export interface ChildBridgeStatusResponse {
    * HAP configuration for this child bridge.
    *
    * Older Homebridge versions used a boolean (`true`/`false`/undefined for default).
-   * Homebridge >= 2.0.3-beta.26 sends the nested object form, including
-   * `externalsOnly`. Both shapes are typed here so the UI can render against
-   * either — the `protocolExternalsOnly` feature flag decides which shape is
-   * authoritative at runtime.
+   * Homebridge >= 2.0.3-beta.26 sends the nested object form. Newer runtimes
+   * may include `externalsOnly` and `disableIdentifyingMaterial`. Both shapes
+   * are typed here so the UI can render against either; feature flags decide
+   * which properties are available at runtime.
    */
-  hap?: boolean | { enabled?: boolean, externalsOnly?: boolean }
+  hap?: boolean | { enabled?: boolean, externalsOnly?: boolean, disableIdentifyingMaterial?: boolean }
 
   /** Matter configuration */
   matterConfig?: {

--- a/ui/src/app/modules/config-editor/config-editor.component.ts
+++ b/ui/src/app/modules/config-editor/config-editor.component.ts
@@ -82,6 +82,7 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
   private isMatterSupported = this.$settings.isFeatureEnabled('matterSupport')
   private isProtocolExternalsOnlyEnabled = this.$settings.isFeatureEnabled('protocolExternalsOnly')
   private isMatterDisableIpv4Enabled = this.$settings.isFeatureEnabled('matterDisableIpv4')
+  private isHapDisableIdentifyingMaterialEnabled = this.$settings.isFeatureEnabled('hapDisableIdentifyingMaterial')
 
   public readonly homebridgeConfig = signal<string>('')
   public readonly originalConfig = signal<string>('')
@@ -648,6 +649,7 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
       isMatterSupported: this.isMatterSupported,
       isProtocolExternalsOnlyEnabled: this.isProtocolExternalsOnlyEnabled,
       isMatterDisableIpv4Enabled: this.isMatterDisableIpv4Enabled,
+      isHapDisableIdentifyingMaterialEnabled: this.isHapDisableIdentifyingMaterialEnabled,
     });
 
     (window as any).monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
@@ -748,7 +750,7 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
                       description: this.$translate.instant('status.widget.network.network_interface'),
                     },
                   },
-                  hap: createHapSchema(this.$translate, this.isProtocolExternalsOnlyEnabled, 'main'),
+                  hap: createHapSchema(this.$translate, this.isProtocolExternalsOnlyEnabled, 'main', this.isHapDisableIdentifyingMaterialEnabled),
                   ...this.isMatterSupported
                     ? { matter: createMatterSchema(this.$translate, this.isProtocolExternalsOnlyEnabled, 'main', this.isMatterDisableIpv4Enabled) }
                     : {},

--- a/ui/src/app/modules/config-editor/config-editor.interfaces.ts
+++ b/ui/src/app/modules/config-editor/config-editor.interfaces.ts
@@ -6,7 +6,11 @@ export interface PluginChildBridge {
   manufacturer?: string
   model?: string
   firmwareRevision?: string
-  hap?: boolean
+  hap?: boolean | {
+    enabled?: boolean
+    externalsOnly?: boolean
+    disableIdentifyingMaterial?: boolean
+  }
   env?: {
     DEBUG?: string
     NODE_OPTIONS?: string
@@ -42,7 +46,11 @@ export interface HomebridgeConfig {
     manufacturer?: string
     model?: string
     firmwareRevision?: string
-    hap?: boolean
+    hap?: boolean | {
+      enabled?: boolean
+      externalsOnly?: boolean
+      disableIdentifyingMaterial?: boolean
+    }
     matter?: {
       port?: number
     }

--- a/ui/src/app/modules/settings/settings.component.html
+++ b/ui/src/app/modules/settings/settings.component.html
@@ -1187,6 +1187,48 @@
               </div>
             </li>
             <!--
+              HAP disableIdentifyingMaterial toggle — only shown when the
+              running Homebridge supports the option (>= 2.2.2-beta.0).
+              The option is independent of HAP enablement so it remains
+              configurable while a bridge is temporarily disabled.
+            -->
+            @if (isHapDisableIdentifyingMaterialEnabled) {
+              <li
+                class="setting-row list-group-item"
+                [class.setting-hidden]="isItemHidden('setting-hap-disable-identifying-material')"
+                [attr.inert]="isItemHidden('setting-hap-disable-identifying-material') || null"
+              >
+                <div class="setting-row-inner d-flex justify-content-between align-items-center">
+                  <span>
+                    {{ 'settings.hap.disable_identifying_material' | translate }}
+                    <span class="badge badge-primary ms-1">{{ 'common.labels.beta' | translate }}</span
+                    ><br />
+                    <small class="grey-text pe-2">{{
+                      'settings.hap.disable_identifying_material_desc' | translate
+                    }}</small>
+                  </span>
+                  <div class="d-flex align-items-center">
+                    <div class="order-1 order-md-2">
+                      <input
+                        type="checkbox"
+                        class="rendux-input"
+                        id="hapDisableIdentifyingMaterial"
+                        [formControl]="hapDisableIdentifyingMaterialFormControl"
+                        [attr.aria-label]="'settings.hap.disable_identifying_material' | translate"
+                      />
+                      <label for="hapDisableIdentifyingMaterial" class="rendux-label ms-3 min-w-50"></label>
+                    </div>
+                    @if (hapDisableIdentifyingMaterialIsSaving()) {
+                      <i
+                        aria-hidden="true"
+                        class="fas fa-floppy-disk primary-text fa-xl me-0 me-md-2 ms-2 ms-md-0 order-2 order-md-1 save-indicator"
+                      ></i>
+                    }
+                  </div>
+                </div>
+              </li>
+            }
+            <!--
               HAP externalsOnly toggle — only shown when:
               - The running Homebridge supports the nested config (>= 2.0.3-beta.26).
               - HAP is currently disabled (validation rule: externalsOnly requires enabled: false).

--- a/ui/src/app/modules/settings/settings.component.ts
+++ b/ui/src/app/modules/settings/settings.component.ts
@@ -133,6 +133,7 @@ export class SettingsComponent implements OnInit {
     ],
     hap: [
       'setting-hap-enabled',
+      'setting-hap-disable-identifying-material',
     ],
     matter: [
       'setting-matter-enabled',
@@ -188,6 +189,9 @@ export class SettingsComponent implements OnInit {
   // When true (Homebridge >= 2.2.0), Matter exposes a disableIpv4 toggle that
   // makes the Matter mDNS responder IPv6-only.
   public isMatterDisableIpv4Enabled = this.$settings.isFeatureEnabled('matterDisableIpv4')
+  // When true (Homebridge >= 2.2.2-beta.0), HAP exposes a toggle that disables
+  // username-derived identifying material in bridge and mDNS service names.
+  public isHapDisableIdentifyingMaterialEnabled = this.$settings.isFeatureEnabled('hapDisableIdentifyingMaterial')
   public isPwa = Boolean(isStandalonePWA())
 
   public readonly hbNameIsInvalid = signal(false)
@@ -350,6 +354,8 @@ export class SettingsComponent implements OnInit {
   // hidden in the UI when hapEnabledFormControl.value === true.
   public readonly hapExternalsOnlyIsSaving = signal(false)
   public hapExternalsOnlyFormControl = new FormControl(false)
+  public readonly hapDisableIdentifyingMaterialIsSaving = signal(false)
+  public hapDisableIdentifyingMaterialFormControl = new FormControl(false)
 
   public readonly matterEnabledIsSaving = signal(false)
   public matterEnabledFormControl = new FormControl(false)
@@ -477,6 +483,10 @@ export class SettingsComponent implements OnInit {
       unavailable.push('setting-matter-disable-ipv4')
     }
 
+    if (!this.isHapDisableIdentifyingMaterialEnabled) {
+      unavailable.push('setting-hap-disable-identifying-material')
+    }
+
     if (!(this.hbLogSizeFormControl.value! > 0)) {
       unavailable.push('setting-terminal-log-truncate')
     }
@@ -525,6 +535,7 @@ export class SettingsComponent implements OnInit {
       display: this.$translate.instant('settings.general.title_display'),
       startup: this.$translate.instant('settings.title_startup_options'),
       network: this.$translate.instant('settings.network.title_network'),
+      hap: `${this.$translate.instant('settings.hap.title')} ${this.$translate.instant('settings.hap.desc')}`,
       matter: `${this.$translate.instant('settings.matter.title')} ${this.$translate.instant('settings.matter.desc')}`,
       terminal: this.$translate.instant('settings.network.title_terminal'),
       security: this.$translate.instant('settings.network.title_security'),
@@ -578,6 +589,10 @@ export class SettingsComponent implements OnInit {
       'setting-network-proxy': this.$translate.instant('settings.network.proxy'),
       'setting-ui-port-network': this.$translate.instant('settings.network.port_ui'),
       'setting-port-overview': this.$translate.instant('settings.ports.title'),
+
+      // HAP section
+      'setting-hap-enabled': `${this.$translate.instant('common.labels.enabled')} ${this.$translate.instant('settings.hap.enabled_desc')}`,
+      'setting-hap-disable-identifying-material': `${this.$translate.instant('settings.hap.disable_identifying_material')} ${this.$translate.instant('settings.hap.disable_identifying_material_desc')}`,
 
       // Matter section
       'setting-matter-enabled': `${this.$translate.instant('common.labels.enabled')} ${this.$translate.instant('settings.matter.enabled_desc')}`,
@@ -2572,14 +2587,16 @@ export class SettingsComponent implements OnInit {
 
   private async initHapSettings(): Promise<void> {
     try {
-      const { enabled, externalsOnly } = await this.$api.get<{ enabled: boolean, externalsOnly?: boolean }>('/config-editor/hap')
+      const { enabled, externalsOnly, disableIdentifyingMaterial } = await this.$api.get<{ enabled: boolean, externalsOnly?: boolean, disableIdentifyingMaterial?: boolean }>('/config-editor/hap')
       this.hapEnabledFormControl.patchValue(enabled, { emitEvent: false })
       this.hapExternalsOnlyFormControl.patchValue(externalsOnly === true, { emitEvent: false })
+      this.hapDisableIdentifyingMaterialFormControl.patchValue(disableIdentifyingMaterial === true, { emitEvent: false })
     } catch (error: any) {
       console.error(error)
       // Fall back to enabled (default) — subscribe regardless so user can change it
       this.hapEnabledFormControl.patchValue(true, { emitEvent: false })
       this.hapExternalsOnlyFormControl.patchValue(false, { emitEvent: false })
+      this.hapDisableIdentifyingMaterialFormControl.patchValue(false, { emitEvent: false })
     }
     this.hapEnabledFormControl.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -2588,6 +2605,11 @@ export class SettingsComponent implements OnInit {
       this.hapExternalsOnlyFormControl.valueChanges
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(value => this.hapExternalsOnlySave(value === true))
+    }
+    if (this.isHapDisableIdentifyingMaterialEnabled) {
+      this.hapDisableIdentifyingMaterialFormControl.valueChanges
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(value => this.hapDisableIdentifyingMaterialSave(value === true))
     }
   }
 
@@ -2603,7 +2625,12 @@ export class SettingsComponent implements OnInit {
     }
     try {
       this.hapExternalsOnlyIsSaving.set(true)
-      await this.$api.put('/config-editor/hap', { enabled: false, externalsOnly: value, restart: false })
+      await this.$api.put('/config-editor/hap', {
+        enabled: false,
+        externalsOnly: value,
+        disableIdentifyingMaterial: this.hapDisableIdentifyingMaterialFormControl.value === true,
+        restart: false,
+      })
       await this.requestFullServiceRestart()
     } catch (error: any) {
       console.error(error)
@@ -2611,6 +2638,29 @@ export class SettingsComponent implements OnInit {
       this.hapExternalsOnlyFormControl.patchValue(!value, { emitEvent: false })
     } finally {
       this.hapExternalsOnlyIsSaving.set(false)
+    }
+  }
+
+  /**
+   * Save whether HAP-NodeJS should omit username-derived identifying material
+   * from bridge display names and mDNS service instance names.
+   */
+  private async hapDisableIdentifyingMaterialSave(value: boolean): Promise<void> {
+    try {
+      this.hapDisableIdentifyingMaterialIsSaving.set(true)
+      await this.$api.put('/config-editor/hap', {
+        enabled: this.hapEnabledFormControl.value !== false,
+        externalsOnly: this.hapExternalsOnlyFormControl.value === true,
+        disableIdentifyingMaterial: value,
+        restart: false,
+      })
+      await this.requestFullServiceRestart()
+    } catch (error: any) {
+      console.error(error)
+      this.$toastr.error(this.$errors.toToastMessage(error), this.$translate.instant('toast.title_error'))
+      this.hapDisableIdentifyingMaterialFormControl.patchValue(!value, { emitEvent: false })
+    } finally {
+      this.hapDisableIdentifyingMaterialIsSaving.set(false)
     }
   }
 
@@ -2632,16 +2682,19 @@ export class SettingsComponent implements OnInit {
       // restart, and let the user restart via the toast when ready.
       try {
         this.hapEnabledIsSaving.set(true)
-        const body: { enabled: boolean, restart: boolean, externalsOnly?: boolean } = { enabled: value, restart: false }
+        const body: { enabled: boolean, restart: boolean, externalsOnly?: boolean, disableIdentifyingMaterial?: boolean } = { enabled: value, restart: false }
         // When disabling HAP, propagate the current externalsOnly setting (if the
-        // feature is supported). When re-enabling, clear it from the form too —
-        // the backend already drops the property entirely.
+        // feature is supported). When re-enabling, clear it from the form too;
+        // the backend removes externalsOnly while retaining independent options.
         if (this.isProtocolExternalsOnlyEnabled) {
           if (!value) {
             body.externalsOnly = this.hapExternalsOnlyFormControl.value === true
           } else {
             this.hapExternalsOnlyFormControl.patchValue(false, { emitEvent: false })
           }
+        }
+        if (this.isHapDisableIdentifyingMaterialEnabled) {
+          body.disableIdentifyingMaterial = this.hapDisableIdentifyingMaterialFormControl.value === true
         }
         await this.$api.put('/config-editor/hap', body)
         await this.requestFullServiceRestart()
@@ -2658,7 +2711,12 @@ export class SettingsComponent implements OnInit {
     try {
       this.hapEnabledIsSaving.set(true)
       if (value) {
-        await this.$api.put('/config-editor/hap', { enabled: true })
+        await this.$api.put('/config-editor/hap', {
+          enabled: true,
+          disableIdentifyingMaterial: this.isHapDisableIdentifyingMaterialEnabled
+            ? this.hapDisableIdentifyingMaterialFormControl.value === true
+            : undefined,
+        })
         setTimeout(() => {
           this.hapEnabledIsSaving.set(false)
           this.$settings.showRestartToast()
@@ -2694,7 +2752,12 @@ export class SettingsComponent implements OnInit {
           void this.$router.navigate(['/restart'], {
             queryParams: { alreadyRestarting: 'true' },
           })
-          await this.$api.put('/config-editor/hap', { enabled: false })
+          await this.$api.put('/config-editor/hap', {
+            enabled: false,
+            disableIdentifyingMaterial: this.isHapDisableIdentifyingMaterialEnabled
+              ? this.hapDisableIdentifyingMaterialFormControl.value === true
+              : undefined,
+          })
         } catch (error: any) {
           if (error === 'Dismiss') {
             this.hapEnabledFormControl.patchValue(true, { emitEvent: false })

--- a/ui/src/i18n/bg.json
+++ b/ui/src/i18n/bg.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/ca.json
+++ b/ui/src/i18n/ca.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/cs.json
+++ b/ui/src/i18n/cs.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/de.json
+++ b/ui/src/i18n/de.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/es.json
+++ b/ui/src/i18n/es.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/fi.json
+++ b/ui/src/i18n/fi.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/fr.json
+++ b/ui/src/i18n/fr.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/he.json
+++ b/ui/src/i18n/he.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/hu.json
+++ b/ui/src/i18n/hu.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/id.json
+++ b/ui/src/i18n/id.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/it.json
+++ b/ui/src/i18n/it.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/ja.json
+++ b/ui/src/i18n/ja.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/mk.json
+++ b/ui/src/i18n/mk.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/nl.json
+++ b/ui/src/i18n/nl.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/no.json
+++ b/ui/src/i18n/no.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/pl.json
+++ b/ui/src/i18n/pl.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/pt-BR.json
+++ b/ui/src/i18n/pt-BR.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/pt.json
+++ b/ui/src/i18n/pt.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/ru.json
+++ b/ui/src/i18n/ru.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/sl.json
+++ b/ui/src/i18n/sl.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/sv.json
+++ b/ui/src/i18n/sv.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/th.json
+++ b/ui/src/i18n/th.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/tr.json
+++ b/ui/src/i18n/tr.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/uk.json
+++ b/ui/src/i18n/uk.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP – це протокол аксесуарів HomeKit, який використовується додатком Apple Home. Він увімкнено за замовчуванням.",
   "settings.hap.disable": "Вимкнути HAP",
   "settings.hap.disable_desc": "Це зупинить публікацію основного мосту HomeKit та одразу перезапустить Homebridge. Дані сполучення HomeKit зберігаються, тож Ви можете знову ввімкнути HAP пізніше.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Чи публікується HAP на головному мосту Homebridge.",
   "settings.hap.enabled_desc_in_place": "Чи опубліковано HAP на головному мосту Homebridge. Увімкнення або вимкнення набуває чинності після перезавантаження. Вимкнення зберігає сполучення HomeKit, тому Ви можете знову ввімкнути HAP пізніше без повторного сполучення.",
   "settings.hap.externals_only": "Тільки зовнішні (HAP)",

--- a/ui/src/i18n/vi.json
+++ b/ui/src/i18n/vi.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/zh-CN.json
+++ b/ui/src/i18n/zh-CN.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",

--- a/ui/src/i18n/zh-TW.json
+++ b/ui/src/i18n/zh-TW.json
@@ -645,6 +645,8 @@
   "settings.hap.desc": "HAP is the HomeKit Accessory Protocol used by the Apple Home app. It is enabled by default.",
   "settings.hap.disable": "Disable HAP",
   "settings.hap.disable_desc": "This will stop publishing the main HomeKit bridge and restart Homebridge straight away. The HomeKit pairing data is preserved so you can re-enable HAP later.",
+  "settings.hap.disable_identifying_material": "Disable Identifying Material (HAP)",
+  "settings.hap.disable_identifying_material_desc": "When on, Homebridge does not append a unique four-character identifier to HAP bridge and external accessory names. Ensure these names are unique on your network to avoid mDNS name collisions and pairing instability.",
   "settings.hap.enabled_desc": "Whether HAP is published on the main Homebridge bridge.",
   "settings.hap.enabled_desc_in_place": "Whether HAP is published on the main Homebridge bridge. Enabling or disabling takes effect after a restart. Disabling keeps the HomeKit pairing, so you can re-enable HAP later without re-pairing.",
   "settings.hap.externals_only": "Externals Only (HAP)",


### PR DESCRIPTION
## Summary

Adds Config UI support for `bridge.hap.disableIdentifyingMaterial`, introduced by [homebridge/homebridge#3965](https://github.com/homebridge/homebridge/pull/3965).

The option is exposed when the running Homebridge version satisfies `>=2.2.2-beta.0`.

- Setting the option to `true` disables HAP-NodeJS's `addIdentifyingMaterial` publish option, preventing username-derived identifying material from being appended to bridge display names and mDNS service instance names.
- Omitting the option, or setting it to `false`, preserves the existing Homebridge behavior.

## Changes

- Add a version-gated `hapDisableIdentifyingMaterial` feature flag.
- Add a toggle to the main HomeKit (HAP) settings section.
- Add the option to platform and accessory child-bridge configuration.
- Support the option in the JSON editor and manual plugin schemas.
- Extend the HAP configuration API, interfaces, and validation.
- Preserve the setting across HAP and child-bridge enable/disable transitions.
- Preserve an existing value when older UI clients omit the field from HAP enablement requests.
- Warn users to keep bridge and external accessory names unique to avoid mDNS name collisions and pairing instability.
- Add English strings and synchronize them across all language files.
- Add regression coverage for version gating, validation, defaults, and persistence.

## Compatibility

The option is hidden for unsupported Homebridge versions, so existing installations retain their current configuration behavior.

Because identifying material normally helps keep advertised HAP service names unique, users who enable this option must ensure that bridge and external accessory names are unique on their network.

## Testing

- `npm test -- test/e2e/config-editor.e2e-spec.ts` [101 tests passed]
- `npm test` [27 test files and 572 tests passed]
- `npm run lint`
- `npm run build:ui`
- `npm run build:server -- --skipLibCheck`
- `git diff --check`