### PR TITLE
fix(plugins): re-establish custom ui sessions on socket reconnect

### DIFF
--- a/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
+++ b/src/modules/custom-plugins/plugins-settings-ui/plugins-settings-ui.service.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'node:child_process'
 import type { EventEmitter } from 'node:events'
 
 import type { HomebridgePluginUiMetadata } from '../../plugins/plugins.interfaces.js'
@@ -18,10 +19,16 @@ import { Logger } from '../../../core/logger/logger.service.js'
 import { RE_PATH_TRAVERSAL, RE_STATIC_ASSET_EXT } from '../../../core/regex.constants.js'
 import { PluginsService } from '../../plugins/plugins.service.js'
 
+// Sent back to the iframe for any request the server cannot answer. It describes the present state
+// rather than a permanent one, because the same text covers a plugin that ships no server-side
+// script and a helper that is momentarily gone.
+const CUSTOM_UI_UNAVAILABLE = 'The custom UI server for this plugin is not available.'
+
 @Injectable()
 export class PluginsSettingsUiService {
   private pluginUiMetadataCache = new NodeCache({ stdTTL: 86400 })
   private pluginUiLastVersionCache = new NodeCache({ stdTTL: 86400 })
+  private customUiCleanups = new WeakMap<EventEmitter, () => void>()
 
   constructor(
     @Inject(Logger) private readonly loggerService: Logger,
@@ -208,48 +215,39 @@ export class PluginsSettingsUiService {
   }
 
   /**
+   * Answer a single request the server cannot forward to a helper, in the shape the iframe bridge
+   * expects: it settles the pending promise held against this request id by rejecting it.
+   */
+  private rejectRequest(pluginName: string, client: EventEmitter, requestId: string) {
+    client.emit('response', { requestId, success: false, data: { message: CUSTOM_UI_UNAVAILABLE } })
+    this.loggerService.debug(`[${pluginName}] custom UI request ${requestId} rejected (no server-side handler available).`)
+  }
+
+  /**
    * Starts the custom ui server-side handler
    */
   async startCustomUiHandler(pluginName: string, client: EventEmitter) {
-    const pluginUi: HomebridgePluginUiMetadata = (this.pluginUiMetadataCache.get(pluginName) as any)
-      || (await this.getPluginUiMetadata(pluginName))
+    // A second start can land on a socket that already has a live handler — the settings modal
+    // reopened on the cached namespace socket, or a buffered start and a subscription-driven one
+    // arriving together. Retiring the previous handler first keeps this socket to one child and
+    // one set of listeners instead of stacking a second of each.
+    this.customUiCleanups.get(client)?.()
 
-    // check the plugin has a server side script
-    if (!await pathExists(resolve(pluginUi.serverPath))) {
-      client.emit('ready', { server: false })
-      return
-    }
+    // Undefined until (and unless) this invocation reaches the fork below.
+    let child: ChildProcess | undefined
 
-    // Pass all env vars to server side script
-    const childEnv = { ...process.env }
-    childEnv.HOMEBRIDGE_STORAGE_PATH = this.configService.storagePath
-    childEnv.HOMEBRIDGE_CONFIG_PATH = this.configService.configPath
-    childEnv.HOMEBRIDGE_UI_VERSION = this.configService.package.version
+    // The ids of the requests handed to this invocation's child and not yet answered.
+    const outstanding = new Set<string>()
 
-    // Launch the server side script
-    const child = fork(pluginUi.serverPath, [], {
-      silent: true,
-      env: childEnv,
-    })
-
-    child.stdout.on('data', (data) => {
-      this.loggerService.log(`[${pluginName}] ${data.toString().trim()}`)
-    })
-
-    child.stderr.on('data', (data) => {
-      this.loggerService.error(`[${pluginName}] ${data.toString().trim()}`)
-    })
-
-    child.on('exit', () => {
-      this.loggerService.debug(`[${pluginName}] custom UI closed (child process ended).`)
-    })
-
-    child.addListener('message', (response: { action: string, payload: any }) => {
-      if (typeof response === 'object' && response.action) {
-        response.action = response.action === 'error' ? 'server_error' : response.action
-        client.emit(response.action, response.payload)
+    // The iframe bridge holds a pending promise per request id with no timeout of its own, so a
+    // request nothing can answer any more has to be settled here or it stalls the plugin UI for
+    // as long as the page stays open.
+    const settleOutstanding = () => {
+      for (const requestId of outstanding) {
+        this.rejectRequest(pluginName, client, requestId)
       }
-    })
+      outstanding.clear()
+    }
 
     // Function to handle cleanup. socket.io often emits both 'disconnect'
     // and 'end' on the same socket close, so cleanup() would otherwise
@@ -265,36 +263,113 @@ export class PluginsSettingsUiService {
       cleaned = true
       this.loggerService.debug(`[${pluginName}] custom UI closing (terminating child process)...`)
 
-      const childPid = child.pid
-      if (child.connected) {
+      // On a disconnect the socket is gone and these emits are harmless; on a modal close or a
+      // supersede the socket survives and the iframe gets its answers.
+      settleOutstanding()
+
+      // Detach this invocation's child from the socket while it drains, so a message it still
+      // manages to send cannot be relayed onto a session a newer child now serves. Its stdout,
+      // stderr and exit handlers stay: their logging is useful right up to the exit.
+      child?.removeAllListeners('message')
+
+      const childPid = child?.pid
+      if (child?.connected) {
         child.disconnect()
       }
-      setTimeout(() => {
-        if (child.killed || !childPid) {
-          return
-        }
-        try {
-          process.kill(childPid, 'SIGTERM')
-        } catch (e: any) {
-          // ESRCH is fine — the child already exited. Surface anything else.
-          if (e?.code !== 'ESRCH') {
-            this.loggerService.warn(`[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`)
+      if (child) {
+        setTimeout(() => {
+          if (child.killed || !childPid) {
+            return
           }
-        }
-      }, 5000)
+          try {
+            process.kill(childPid, 'SIGTERM')
+          } catch (e: any) {
+            // ESRCH is fine — the child already exited. Surface anything else.
+            if (e?.code !== 'ESRCH') {
+              this.loggerService.warn(`[${pluginName}] failed to SIGTERM child pid ${childPid}: ${e.message}`)
+            }
+          }
+        }, 5000)
+      }
 
       client.removeAllListeners('end')
       client.removeAllListeners('disconnect')
       client.removeAllListeners('request')
+      this.customUiCleanups.delete(client)
     }
 
-    client.on('request', (request) => {
-      if (child.connected) {
+    this.customUiCleanups.set(client, cleanup)
+
+    // Bind the socket's listeners synchronously, before the lookups below suspend: they belong to
+    // the socket for its whole session, and a request that arrives while a helper is being
+    // resolved still has to be answered rather than dropped.
+    client.on('request', (request: { requestId?: string }) => {
+      if (child?.connected) {
+        if (request?.requestId) {
+          outstanding.add(request.requestId)
+        }
         child.send(request)
+      } else if (request?.requestId) {
+        this.rejectRequest(pluginName, client, request.requestId)
       }
     })
 
     client.on('disconnect', cleanup)
     client.on('end', cleanup)
+
+    const pluginUi: HomebridgePluginUiMetadata = (this.pluginUiMetadataCache.get(pluginName) as any)
+      || (await this.getPluginUiMetadata(pluginName))
+
+    // check the plugin has a server side script
+    const hasServerScript = await pathExists(resolve(pluginUi.serverPath))
+
+    // An invocation superseded, or a socket closed, while the lookups above were in flight must
+    // leave no trace of itself: no stray ready, and no orphan child.
+    if (cleaned) {
+      return
+    }
+
+    if (!hasServerScript) {
+      client.emit('ready', { server: false })
+      return
+    }
+
+    // Pass all env vars to server side script
+    const childEnv = { ...process.env }
+    childEnv.HOMEBRIDGE_STORAGE_PATH = this.configService.storagePath
+    childEnv.HOMEBRIDGE_CONFIG_PATH = this.configService.configPath
+    childEnv.HOMEBRIDGE_UI_VERSION = this.configService.package.version
+
+    // Launch the server side script
+    child = fork(pluginUi.serverPath, [], {
+      silent: true,
+      env: childEnv,
+    })
+
+    child.stdout.on('data', (data) => {
+      this.loggerService.log(`[${pluginName}] ${data.toString().trim()}`)
+    })
+
+    child.stderr.on('data', (data) => {
+      this.loggerService.error(`[${pluginName}] ${data.toString().trim()}`)
+    })
+
+    child.on('exit', () => {
+      this.loggerService.debug(`[${pluginName}] custom UI closed (child process ended).`)
+
+      // A crash, or a kill from the cleanup path, can take the child down with requests still in
+      // flight. Nothing will ever answer those, so settle them here.
+      settleOutstanding()
+    })
+
+    child.addListener('message', (response: { action: string, payload: any }) => {
+      if (typeof response === 'object' && response.action) {
+        if (response.action === 'response' && response.payload?.requestId) {
+          outstanding.delete(response.payload.requestId)
+        }
+        response.action = response.action === 'error' ? 'server_error' : response.action
+        client.emit(response.action, response.payload)
+      }
+    })
   }
 }

--- a/test/e2e/plugin-settings-ui.e2e-spec.ts
+++ b/test/e2e/plugin-settings-ui.e2e-spec.ts
@@ -1,5 +1,6 @@
 import type { NestFastifyApplication } from '@nestjs/platform-fastify'
 import type { TestingModule } from '@nestjs/testing'
+import type { MockInstance } from 'vitest'
 
 import { resolve } from 'node:path'
 import process from 'node:process'
@@ -417,6 +418,276 @@ describe('PluginsSettingsUiController (e2e)', () => {
       const guards = reflector.get<any[]>('__guards__', PluginsSettingsUiController)
       expect(guards, 'no guards applied to PluginsSettingsUiController').toBeDefined()
       expect(guards.includes(CookieAuthGuard)).toBe(true)
+    })
+  })
+
+  describe('startCustomUiHandler sessions', () => {
+    // The message the service sends back for any request it cannot forward to a helper.
+    const customUiUnavailable = 'The custom UI server for this plugin is not available.'
+
+    // Every wait below spans a real child process booting, answering over IPC or exiting, so these
+    // poll for the outcome instead of sleeping for a guessed interval.
+    const waitOptions = { interval: 50, timeout: 5000 }
+
+    let pluginsSettingsUiService: PluginsSettingsUiService
+
+    beforeEach(() => {
+      pluginsSettingsUiService = app.get(PluginsSettingsUiService)
+    })
+
+    // Each test drives its own socket, so no listener, child or spy state carries between them.
+    async function createClient() {
+      const { EventEmitter } = await import('node:events')
+      const client = new EventEmitter()
+
+      return { client, emitSpy: vi.spyOn(client, 'emit') }
+    }
+
+    // Wait for the socket to receive an event and hand back the payload it carried.
+    async function waitForEmit(emitSpy: MockInstance, event: string, match: (payload: any) => boolean = () => true): Promise<any> {
+      let payload: any
+
+      await vi.waitFor(() => {
+        const call = emitSpy.mock.calls.find(([name, value]) => name === event && match(value))
+        if (!call) {
+          throw new Error(`the socket has not received a matching '${event}' event`)
+        }
+        payload = call[1]
+      }, waitOptions)
+
+      return payload
+    }
+
+    function countEmits(emitSpy: MockInstance, event: string, match: (payload: any) => boolean = () => true): number {
+      return emitSpy.mock.calls.filter(([name, value]) => name === event && match(value)).length
+    }
+
+    it('rejects a request when the plugin ships no server-side script', async () => {
+      const { client, emitSpy } = await createClient()
+
+      await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+      client.emit('request', { requestId: 'r1', path: '/x' })
+
+      expect(emitSpy).toHaveBeenCalledWith('response', {
+        requestId: 'r1',
+        success: false,
+        data: { message: customUiUnavailable },
+      })
+
+      client.emit('end')
+    })
+
+    it('keeps sessions on separate sockets isolated from each other', async () => {
+      const a = await createClient()
+      const b = await createClient()
+
+      await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', a.client)
+      await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', b.client)
+
+      a.client.emit('request', { requestId: 'r-a', path: '/x' })
+
+      expect(a.emitSpy).toHaveBeenCalledWith('response', {
+        requestId: 'r-a',
+        success: false,
+        data: { message: customUiUnavailable },
+      })
+      expect(countEmits(b.emitSpy, 'response')).toBe(0)
+
+      a.client.emit('disconnect')
+
+      expect(a.client.listenerCount('request')).toBe(0)
+      expect(a.client.listenerCount('disconnect')).toBe(0)
+      expect(a.client.listenerCount('end')).toBe(0)
+      expect(b.client.listenerCount('request')).toBe(1)
+      expect(b.client.listenerCount('disconnect')).toBe(1)
+      expect(b.client.listenerCount('end')).toBe(1)
+
+      b.client.emit('end')
+    })
+
+    it('collapses overlapping starts on one socket into a single session', async () => {
+      const { client, emitSpy } = await createClient()
+
+      const first = pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+      const second = pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+      await Promise.all([first, second])
+
+      expect(emitSpy).toHaveBeenCalledExactlyOnceWith('ready', { server: false })
+      expect(client.listenerCount('request')).toBe(1)
+      expect(client.listenerCount('disconnect')).toBe(1)
+      expect(client.listenerCount('end')).toBe(1)
+
+      client.emit('end')
+    })
+
+    describe('with a helper child running', () => {
+      // A dependency-free stand-in for a plugin's server-side script, speaking the raw IPC protocol
+      // and mirroring how @homebridge/plugin-ui-utils behaves: it announces itself once it boots and
+      // terminates itself the moment the parent closes the IPC channel.
+      const helperScript = `
+process.send({ action: 'ready', payload: { server: true } })
+
+process.on('disconnect', () => {
+  process.kill(process.pid, 'SIGTERM')
+})
+
+process.on('message', (request) => {
+  if (request.path === '/exit') {
+    process.exit(0)
+  }
+
+  if (request.path === '/hang') {
+    return
+  }
+
+  process.send({ action: 'response', payload: { requestId: request.requestId, success: true, data: { echo: request.path } } })
+})
+`
+
+      let serverPath: string
+
+      beforeAll(async () => {
+        serverPath = resolve(pluginsPath, 'homebridge-mock-plugin/homebridge-ui/server.js')
+        await writeFile(serverPath, helperScript)
+      })
+
+      afterAll(async () => {
+        await remove(serverPath)
+      })
+
+      it('relays a request to the helper and returns its response', async () => {
+        const { client, emitSpy } = await createClient()
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+
+        expect(await waitForEmit(emitSpy, 'ready')).toEqual({ server: true })
+
+        client.emit('request', { requestId: 'r2', path: '/hello' })
+
+        expect(await waitForEmit(emitSpy, 'response', payload => payload?.requestId === 'r2'))
+          .toEqual({ requestId: 'r2', success: true, data: { echo: '/hello' } })
+
+        client.emit('end')
+      })
+
+      it('supersedes the previous helper when the same socket starts again', async () => {
+        const { client, emitSpy } = await createClient()
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        await waitForEmit(emitSpy, 'ready')
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+
+        expect(client.listenerCount('request')).toBe(1)
+
+        client.emit('request', { requestId: 'r-second', path: '/again' })
+
+        expect(await waitForEmit(emitSpy, 'response', payload => payload?.requestId === 'r-second'))
+          .toEqual({ requestId: 'r-second', success: true, data: { echo: '/again' } })
+
+        // A listener left behind by the superseded session would answer this same request id a
+        // second time, with a rejection from its own dead child.
+        expect(countEmits(emitSpy, 'response', payload => payload?.requestId === 'r-second')).toBe(1)
+
+        client.emit('end')
+      })
+
+      it('rejects requests that arrive once the helper has died', async () => {
+        const { client, emitSpy } = await createClient()
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        await waitForEmit(emitSpy, 'ready')
+
+        client.emit('request', { requestId: 'r-exit', path: '/exit' })
+
+        // The child's `connected` flag drops a moment after the child itself is gone, so a single
+        // post-exit request can still be handed to it and vanish. Re-emitting under a fresh request
+        // id each poll, and only accepting an answer to the id emitted in that same tick, pins the
+        // rejection to the arrival path rather than to any later settlement.
+        let attempt = 0
+        let rejection: any
+
+        await vi.waitFor(() => {
+          const requestId = `r-dead-${attempt++}`
+          client.emit('request', { requestId, path: '/x' })
+          const call = emitSpy.mock.calls.find(([name, payload]) => name === 'response' && payload?.requestId === requestId)
+          if (!call) {
+            throw new Error('the socket has not received a rejection yet')
+          }
+          rejection = call[1]
+        }, waitOptions)
+
+        expect(rejection).toEqual({
+          requestId: expect.stringMatching(/^r-dead-\d+$/),
+          success: false,
+          data: { message: customUiUnavailable },
+        })
+
+        client.emit('end')
+      })
+
+      it('tears the session down on disconnect and re-establishes it on a later start', async () => {
+        const { client, emitSpy } = await createClient()
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        await waitForEmit(emitSpy, 'ready')
+
+        client.emit('disconnect')
+
+        expect(client.listenerCount('request')).toBe(0)
+        expect(client.listenerCount('disconnect')).toBe(0)
+        expect(client.listenerCount('end')).toBe(0)
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+
+        expect(client.listenerCount('request')).toBe(1)
+        expect(client.listenerCount('disconnect')).toBe(1)
+        expect(client.listenerCount('end')).toBe(1)
+
+        client.emit('request', { requestId: 'r-again', path: '/back' })
+
+        expect(await waitForEmit(emitSpy, 'response', payload => payload?.requestId === 'r-again'))
+          .toEqual({ requestId: 'r-again', success: true, data: { echo: '/back' } })
+
+        client.emit('end')
+      })
+
+      it('forks a single helper when starts overlap', async () => {
+        const { client, emitSpy } = await createClient()
+
+        const first = pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        const second = pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        await Promise.all([first, second])
+        await waitForEmit(emitSpy, 'ready')
+
+        expect(client.listenerCount('request')).toBe(1)
+
+        client.emit('request', { requestId: 'r-single', path: '/single' })
+
+        expect(await waitForEmit(emitSpy, 'response', payload => payload?.requestId === 'r-single'))
+          .toEqual({ requestId: 'r-single', success: true, data: { echo: '/single' } })
+
+        // Both invocations have long since settled by now, so a second child would have announced
+        // itself and answered alongside the first.
+        expect(countEmits(emitSpy, 'ready')).toBe(1)
+        expect(countEmits(emitSpy, 'response', payload => payload?.requestId === 'r-single')).toBe(1)
+
+        client.emit('end')
+      })
+
+      it('settles in-flight requests when the helper dies', async () => {
+        const { client, emitSpy } = await createClient()
+
+        await pluginsSettingsUiService.startCustomUiHandler('homebridge-mock-plugin', client)
+        await waitForEmit(emitSpy, 'ready')
+
+        client.emit('request', { requestId: 'r-hang', path: '/hang' })
+        client.emit('request', { requestId: 'r-exit2', path: '/exit' })
+
+        expect(await waitForEmit(emitSpy, 'response', payload => payload?.requestId === 'r-hang'))
+          .toEqual({ requestId: 'r-hang', success: false, data: { message: customUiUnavailable } })
+
+        client.emit('end')
+      })
     })
   })
 

--- a/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
+++ b/ui/src/app/core/plugins/custom-plugins/custom-plugins.component.ts
@@ -215,7 +215,14 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
       return
     }
 
-    this.io.socket.emit('start', plugin.name)
+    // The server-side helper is tied to the socket and dies with it, so the plugin has to be
+    // introduced to the server on every connection, not just the first. Subscribing to `connected`
+    // covers all three cases with one path — a cache-hit reopen, the initial connect and each
+    // reconnect — and it is the only place 'start' is emitted: emitting directly as well would
+    // fire it twice on a cache hit (see the WsService doc comment).
+    this.io.connected!.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.io.socket.emit('start', plugin.name)
+    })
 
     // The iframe is only assigned once the socket reports 'ready' (loadUi),
     // and its contentWindow is nulled when the modal is torn down, so guard
@@ -239,6 +246,13 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
   private loadUi(): void {
     const plugin = this.plugin
     if (!plugin) {
+      return
+    }
+
+    // Each connection brings a freshly spawned helper announcing itself with 'ready', and that
+    // helper serves the iframe already on the page. Reassigning the src would reload the plugin UI
+    // and throw away whatever the user has typed into it, so it is assigned once per modal.
+    if (this.iframe) {
       return
     }
 
@@ -381,6 +395,15 @@ export class CustomPluginsComponent implements OnInit, OnDestroy {
   }
 
   private handleRequest(event: MessageEvent): void {
+    // socket.io flushes its buffered emits before the 'connect' event fires, so a request buffered
+    // while the socket is down would reach the fresh server-side socket ahead of the 'start' that
+    // gives it a helper, and nothing would answer it. Failing fast instead keeps the plugin UI's
+    // promise chain moving and leaves its own retry logic free to recover once the socket is back.
+    if (!this.io.socket.connected) {
+      this.requestResponse(event, { message: this.$translate.instant('plugins.settings.message_ui_offline') }, false)
+      return
+    }
+
     this.io.socket.emit('request', event.data)
   }
 

--- a/ui/src/i18n/bg.json
+++ b/ui/src/i18n/bg.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Open Config Editor",
   "plugins.settings.message_consult_documentation": "Please consult the plugin documentation for instructions on how to correctly configure this plugin.",
   "plugins.settings.message_manual_config_required": "This plugin must be configured manually using the Homebridge UI Config Editor.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Конфигурацията на добавката е запаметена",
   "plugins.settings.restart_required": "Рестартирай Homebridge за да влезнат в сила промените.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/ca.json
+++ b/ui/src/i18n/ca.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Obrir editor de configuració",
   "plugins.settings.message_consult_documentation": "Si us plau consulte la documentació del plugin per a més informació i instruccions de com configurar aquest plugin correctament.",
   "plugins.settings.message_manual_config_required": "Aquest plugin s'ha de configurar manualment usant l'Editor de Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configuració del plugin guardada",
   "plugins.settings.restart_required": "Reiniciar Homebridge per aplicar els canvis.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/cs.json
+++ b/ui/src/i18n/cs.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Otevřít editor konfigurace",
   "plugins.settings.message_consult_documentation": "Prostudujte si prosím dokumentaci pluginu jak správně nakonfigurovat tento plugin.",
   "plugins.settings.message_manual_config_required": "Tento plugin musí být manuálně nastaven použitím Homebridge UI Editoru konfigurace.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Konfigurace pluginu byla uložena",
   "plugins.settings.restart_required": "Chcete-li použít změny, restartujte aplikaci Homebridge.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/de.json
+++ b/ui/src/i18n/de.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Konfigurations-Editor öffnen",
   "plugins.settings.message_consult_documentation": "Bitte lies die Plugin-Dokumentation, um das Plugin korrekt zu konfigurieren.",
   "plugins.settings.message_manual_config_required": "Dieses Plugin muss mithilfe des Homebridge UI Config Editors manuell konfiguriert werden.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin-Konfiguration gespeichert",
   "plugins.settings.restart_required": "Starte Homebridge neu, um die Änderungen zu übernehmen.",
   "plugins.stats": "Plugin-Statistiken",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Open Config Editor",
   "plugins.settings.message_consult_documentation": "Please consult the plugin documentation for instructions on how to correctly configure this plugin.",
   "plugins.settings.message_manual_config_required": "This plugin must be configured manually using the Homebridge UI Config Editor.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin Config Saved",
   "plugins.settings.restart_required": "Restart Homebridge to apply the changes.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/es.json
+++ b/ui/src/i18n/es.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Abrir Editor de Configuración",
   "plugins.settings.message_consult_documentation": "Por favor consulta la documentación del plugin para más información e instrucciones de cómo configurar correctamente este plugin.",
   "plugins.settings.message_manual_config_required": "Este plugin debe ser configurado manualmente usando el Editor de Configuración de Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configuración del plugin guardada",
   "plugins.settings.restart_required": "Reinicia Homebridge para aplicar los cambios.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/fi.json
+++ b/ui/src/i18n/fi.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Avaa Asetusten muokkain",
   "plugins.settings.message_consult_documentation": "Ole hyvä ja tutustu laajennuksen ohjeisiin asetusten määrittelelmiseksi.",
   "plugins.settings.message_manual_config_required": "Tämä laajennus täytyy määritellä käsin Homebridge UI Asetusten muokkaimella.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Laajennuksen asetukset talletettu",
   "plugins.settings.restart_required": "Uudelleenkäynnistä Homebridge toimintojen käyttöönottamiseksi.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/fr.json
+++ b/ui/src/i18n/fr.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Ouvrir l'éditeur de Config",
   "plugins.settings.message_consult_documentation": "Consultez la documentation du plugin pour le configurer de manière correcte.",
   "plugins.settings.message_manual_config_required": "Ce plugin doit être configuré manuellement en utilisant l'éditeur de Config de Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configuration du plugin enregistrée",
   "plugins.settings.restart_required": "Redémarrer Homebridge pour appliquer les changements.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/he.json
+++ b/ui/src/i18n/he.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "פתח עורך קונפיגורציה",
   "plugins.settings.message_consult_documentation": "אנא בודק את התיעוד של התוסף על מנת לקבל הוראות קונפיגורציה לתוסף",
   "plugins.settings.message_manual_config_required": "התוסף הזה חייב להיות מוגדר ידנית בעזרת עורך הקונפיגורציה של הומברידג'",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "קונפוגרוציה של תוסף נשמרה",
   "plugins.settings.restart_required": "אתחל את הומברידג' כדי להחיל את השינויים",
   "plugins.stats": "סטטיסטיקות תוסף",

--- a/ui/src/i18n/hu.json
+++ b/ui/src/i18n/hu.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Open Config Editor",
   "plugins.settings.message_consult_documentation": "Please consult the plugin documentation for instructions on how to correctly configure this plugin.",
   "plugins.settings.message_manual_config_required": "This plugin must be configured manually using the Homebridge UI Config Editor.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin beállítások mentve",
   "plugins.settings.restart_required": "Indítsa újra a Homebridge-t a beállítások alkalmazásához.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/id.json
+++ b/ui/src/i18n/id.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Buka Editor Konfigurasi",
   "plugins.settings.message_consult_documentation": "Silakan baca dokumentasi plugin untuk instruksi tentang cara mengkonfigurasi plugin ini dengan benar.",
   "plugins.settings.message_manual_config_required": "Plugin ini harus dikonfigurasi secara manual menggunakan Homebridge UI Config Editor",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Konfigurasi Plugin Tersimpan",
   "plugins.settings.restart_required": "Homebridge perlu diulang kembali untuk menerapkan perubahan.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/it.json
+++ b/ui/src/i18n/it.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Apri l'editor della configurazione",
   "plugins.settings.message_consult_documentation": "Per piacere consulta la documentazione del plugin per sapere come configurarlo correttamente.",
   "plugins.settings.message_manual_config_required": "Questo plugin deve essere configurato manualmente usando l'editor della configurazione di Homebridge UI X.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configurazione dei plugin salvata",
   "plugins.settings.restart_required": "Riavvia Homebridge per applicare le modifiche.",
   "plugins.stats": "Statistiche plugin",

--- a/ui/src/i18n/ja.json
+++ b/ui/src/i18n/ja.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "設定エディタを開く",
   "plugins.settings.message_consult_documentation": "プラグインの正しい設定方法はドキュメントを参照してください。",
   "plugins.settings.message_manual_config_required": "このプラグインの設定はHomebridge UI設定エディタで手動で行う必要があります。",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "プラグイン設定を保存しました",
   "plugins.settings.restart_required": "変更を適用するにはHomebridgeを再起動してください",
   "plugins.stats": "プラグイン統計",

--- a/ui/src/i18n/ko.json
+++ b/ui/src/i18n/ko.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Config 에디터 열기",
   "plugins.settings.message_consult_documentation": "플러그인을 올바르게 구성하는 방법에 대한 내용은 해당 플러그인의 문서를 참고해주세요.",
   "plugins.settings.message_manual_config_required": "이 플러그인은 Homebridge UI Config 에디터를 사용하여 직접 Config 정보를 추가해야합니다.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "플러그인 Config가 저장되었습니다",
   "plugins.settings.restart_required": "변경사항을 반영하려면 Homebridge 재시작해야합니다.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/mk.json
+++ b/ui/src/i18n/mk.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Отвори уредник за конфигурација",
   "plugins.settings.message_consult_documentation": "Ве молиме да се консултирате со документацијата на плагинот за инструкции како да го конфигурирате истиот.",
   "plugins.settings.message_manual_config_required": "Овој плагин мора да се конфигурира рачно во Homebridge UI уредникот за конфигурација.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Конфигурацијата на плагинот е зачувана",
   "plugins.settings.restart_required": "Рестартирајте го Homebridge за промените да бидат рефлектирани.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/nl.json
+++ b/ui/src/i18n/nl.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Open Config Editor",
   "plugins.settings.message_consult_documentation": "Raadpleeg a.u.b. de plugin documentatie voor instructies hoe deze plugin correct te configureren.",
   "plugins.settings.message_manual_config_required": "Deze plugin moet handmatig geconigureerd worden met de Homebridge UI Config Editor.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin Configuratie Bewaard",
   "plugins.settings.restart_required": "Start Homebridge opnieuw om de wijzigingen toe te passen.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/no.json
+++ b/ui/src/i18n/no.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Open Config Editor",
   "plugins.settings.message_consult_documentation": "Please consult the plugin documentation for instructions on how to correctly configure this plugin.",
   "plugins.settings.message_manual_config_required": "This plugin must be configured manually using the Homebridge UI Config Editor.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin Config lagret",
   "plugins.settings.restart_required": "Start Homebridge på nytt for å iverksette endringene.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/pl.json
+++ b/ui/src/i18n/pl.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Otwórz edytor konfiguracji",
   "plugins.settings.message_consult_documentation": "Sprawdż na stronie wsparcia tej wtyczki, jak ją poprawnie skonfigurować.",
   "plugins.settings.message_manual_config_required": "Ta wtyczka musi być skonfigurowana ręcznie z użyciem wbudowanego edytora.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Zapisano konfigurację wtyczki",
   "plugins.settings.restart_required": "Zrestartuj serwer, aby zastosować zmiany.",
   "plugins.stats": "Statystyki wtyczek",

--- a/ui/src/i18n/pt-BR.json
+++ b/ui/src/i18n/pt-BR.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Abrir editor de configurações",
   "plugins.settings.message_consult_documentation": "Consulte a documentação do plugin para ter instruções de como configurá-lo corretamente.",
   "plugins.settings.message_manual_config_required": "Este plugin precisa ser configurado manualmente utilizando o editor de configurações do Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configurações do Plugin Salvas",
   "plugins.settings.restart_required": "Reinicie o Homebridge para aplicar as mudanças.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/pt.json
+++ b/ui/src/i18n/pt.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Abrir o Editor de Configuração",
   "plugins.settings.message_consult_documentation": "Por favor consulte a documentação do plugin para obter instruções de como o configurar corretamente.",
   "plugins.settings.message_manual_config_required": "É necessário configurar manualmente este plugin através do Editor de Configuração do Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Configurações do Plugin Gravadas",
   "plugins.settings.restart_required": "Reinicie o Homebridge para aplicar as mudanças.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/ru.json
+++ b/ui/src/i18n/ru.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Открыть редактор конфигурации",
   "plugins.settings.message_consult_documentation": "Пожалуйста, ознакомьтесь с документацией плагина для правильной настройки.",
   "plugins.settings.message_manual_config_required": "Этот плагин должен быть настроен вручную через редактор конфигурации Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Конфигурация плагина сохранена",
   "plugins.settings.restart_required": "Перезапустите Homebridge для применения изменений.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/sl.json
+++ b/ui/src/i18n/sl.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Odpri Config Urejevalec",
   "plugins.settings.message_consult_documentation": "Za navodila o pravilni konfiguraciji tega vtičnika glejte dokumentacijo vtičnika.",
   "plugins.settings.message_manual_config_required": "Ta vtičnik morate konfigurirati ročno z urejevalnikom konfiguracije vmesnika Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Konfiguracija vtičnika je shranjena",
   "plugins.settings.restart_required": "Za uveljavitev sprememb znova zaženite Homebridge.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/sv.json
+++ b/ui/src/i18n/sv.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Öppna konfigurationsredigerare",
   "plugins.settings.message_consult_documentation": "Se plugin-dokumentationen för instruktioner om hur du korrekt konfigurerar detta plugin.",
   "plugins.settings.message_manual_config_required": "Detta plugin måste konfigureras manuellt med Homebridge UI konfigurationsredigerare.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin-konfiguration sparad",
   "plugins.settings.restart_required": "Starta om Homebridge för att tillämpa ändringarna.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/th.json
+++ b/ui/src/i18n/th.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "เปิด Config Editor",
   "plugins.settings.message_consult_documentation": "โปรดดูเอกสารประกอบของปลั๊กอินสำหรับคำแนะนำในการกำหนดค่าปลั๊กอินนี้อย่างถูกต้อง",
   "plugins.settings.message_manual_config_required": "ปลั๊กอินของเขาต้องได้รับการกำหนดค่าด้วยตนเองโดยใช้ Homebridge UI Config Editor",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "บันทึกการกำหนดค่าปลั๊กอินแล้ว",
   "plugins.settings.restart_required": "รีสตาร์ท Homebridge เพื่อใช้การเปลี่ยนแปลง",
   "plugins.stats": "สถิติปลั๊กอิน",

--- a/ui/src/i18n/tr.json
+++ b/ui/src/i18n/tr.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Yapılandırma Düzenleyiciyi Aç",
   "plugins.settings.message_consult_documentation": "Bu eklentiyi gerektiği şekilde yapılandırmak için lütfen eklenti dokümantasyonuna başvurun.",
   "plugins.settings.message_manual_config_required": "Bu eklenti Homebridge UI Yapılandırma Düzenleyicisi kullanılarak el ile yapılandırılmalıdır.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Eklenti Yapılandırması Kaydedildi",
   "plugins.settings.restart_required": "Değişiklikleri uygulamak için Homebridge'i yeniden başlatın.",
   "plugins.stats": "Plugin Statistics",

--- a/ui/src/i18n/uk.json
+++ b/ui/src/i18n/uk.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Відкрийте редактор конфігурацій",
   "plugins.settings.message_consult_documentation": "Будь ласка, зверніться до документації до плагіна, щоб отримати інструкції щодо правильного налаштування цього плагіна.",
   "plugins.settings.message_manual_config_required": "Цей плагін потрібно налаштувати вручну за допомогою редактора конфігурації інтерфейсу користувача Homebridge.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Конфігурація плагіна збережена",
   "plugins.settings.restart_required": "Перезавантажте Homebridge, щоб зміни почали діяти.",
   "plugins.stats": "Статистика плагіна",

--- a/ui/src/i18n/vi.json
+++ b/ui/src/i18n/vi.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "Mở Trình chỉnh sửa cấu hình",
   "plugins.settings.message_consult_documentation": "Vui lòng tham khảo tài liệu plugin để cấu hình đúng cách.",
   "plugins.settings.message_manual_config_required": "Plugin này phải được cấu hình thủ công bằng Trình chỉnh sửa cấu hình của Homebridge UI.",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Đã lưu cấu hình Plugin",
   "plugins.settings.restart_required": "Khởi động lại Homebridge để áp dụng thay đổi.",
   "plugins.stats": "Thống kê Plugin",

--- a/ui/src/i18n/zh-CN.json
+++ b/ui/src/i18n/zh-CN.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "打开配置编辑器",
   "plugins.settings.message_consult_documentation": "请参考插件文档以进行正确配置。",
   "plugins.settings.message_manual_config_required": "此插件必须手动通过 Homebridge UI 配置编辑器进行配置。",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "插件配置已保存",
   "plugins.settings.restart_required": "重启 Homebridge 以应用更改。",
   "plugins.stats": "插件统计",

--- a/ui/src/i18n/zh-TW.json
+++ b/ui/src/i18n/zh-TW.json
@@ -529,6 +529,7 @@
   "plugins.settings.label_open_config_editor": "開啟 Config 編輯器",
   "plugins.settings.message_consult_documentation": "請參閱 Plugin 文件以了解如何正確的設定此 Plugin。",
   "plugins.settings.message_manual_config_required": "此 Plugin 必須使用 Homebridge UI Config 編輯器進行手動編輯。",
+  "plugins.settings.message_ui_offline": "Not connected to the Homebridge UI server.",
   "plugins.settings.plugin_config_saved": "Plugin Config 已儲存",
   "plugins.settings.restart_required": "重新啟動 Homebridge 方能使 Config 的變更生效。",
   "plugins.stats": "Plugin Statistics",


### PR DESCRIPTION
## Summary

A plugin's custom settings UI dies permanently whenever its socket connection drops and comes back. The classic trigger is iPadOS suspending Safari on an app switch, but a laptop sleep or a transient network blip does it too. The server kills the helper child on any socket disconnect (`plugins-settings-ui.service.ts`), and the only thing that ever spawns one is the `start` message the modal emits once at init (`custom-plugins.component.ts`) - so a surviving page holds a bridge whose every request is silently dropped. `plugin-ui-utils` keeps a pending promise per request with no timeout, which means every `homebridge.request()` on that page hangs forever, and only a full page reload recovers. Watching a live instance during a stuck window shows zero bridge traffic - the requests simply vanish.

## The fix

- **Client**: the modal takes its `start` signal from the namespace's `connected` ReplaySubject as the sole start path - the same idiom the status widgets and restart components already use, and the pattern the `WsService` doc comment recommends. First connect, cache-hit reopen, and every reconnect flow through one path, so each fresh server-side socket gets introduced to the plugin it serves.
- **Server**: `startCustomUiHandler` binds its socket listeners synchronously and supersedes the previous handler when `start` repeats on one socket - one child and one listener set per socket, never a stack. A request arriving with no live helper gets an immediate `{ success: false }` response instead of vanishing, and requests already in flight when a helper dies are settled the same way, so a plugin UI fails fast rather than hanging.
- **Iframe**: the iframe `src` is assigned once per modal, so the `ready` re-fired by a freshly spawned helper serves the surviving page instead of reloading it - the user's mid-edit state stays intact. While the socket is down, the modal answers iframe requests locally with a translated failure (socket.io flushes buffered emits before the `connect` event fires, so a buffered request would outrun the `start` that gives it a helper).

Two behaviors change as a deliberate result: a plugin that ships no server-side script now answers stray `homebridge.request()` calls with a failure rather than dropping them, and a helper crash settles its in-flight requests. Well-behaved plugin UIs recover transparently - the helper respawns on reconnect and the plugin's own state re-elicitation takes it from there.

## Testing

- [x] `npm run lint` clean at `--max-warnings=0`
- [x] `npm run build` clean (server + ui)
- [x] `npm run test`: 27 files, 592 tests passing (583 baseline + 9 new)
- [x] Nine new e2e cases in `plugin-settings-ui.e2e-spec.ts`: dead-helper rejection, in-flight settlement, supersede on repeated start, overlapping starts collapsing to a single child, disconnect cleanup and re-establishment, and multi-client isolation - driven against a real forked helper fixture speaking the raw IPC protocol
- [x] Verified the new cases fail against the pre-fix source (7 of 9; the other 2 pin pre-existing behavior that must not change)
- [x] Live suspend/resume verification on iPadOS against a patched instance
